### PR TITLE
ALSA: hda - Add mic fixup for Gigabyte BXBT-2807

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -3910,6 +3910,7 @@ enum {
 	ALC269_FIXUP_THINKPAD_ACPI,
 	ALC255_FIXUP_DELL1_MIC_NO_PRESENCE,
 	ALC255_FIXUP_HEADSET_MODE,
+	ALC283_FIXUP_BXBT2807_MIC,
 };
 
 static const struct hda_fixup alc269_fixups[] = {
@@ -4257,6 +4258,13 @@ static const struct hda_fixup alc269_fixups[] = {
 		.type = HDA_FIXUP_FUNC,
 		.v.func = alc_fixup_headset_mode_alc255,
 	},
+	[ALC283_FIXUP_BXBT2807_MIC] = {
+		.type = HDA_FIXUP_PINS,
+		.v.pins = (const struct hda_pintbl[]) {
+			{ 0x19, 0x04a110f0 },
+			{ },
+		},
+	},
 };
 
 static const struct snd_pci_quirk alc269_fixup_tbl[] = {
@@ -4347,6 +4355,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
 	SND_PCI_QUIRK(0x104d, 0x9084, "Sony VAIO", ALC275_FIXUP_SONY_HWEQ),
 	SND_PCI_QUIRK_VENDOR(0x104d, "Sony VAIO", ALC269_FIXUP_SONY_VAIO),
 	SND_PCI_QUIRK(0x10cf, 0x1475, "Lifebook", ALC269_FIXUP_LIFEBOOK),
+	SND_PCI_QUIRK(0x1458, 0xfa53, "Gigabyte BXBT-2807", ALC283_FIXUP_BXBT2807_MIC),
 	SND_PCI_QUIRK(0x17aa, 0x20f2, "Thinkpad SL410/510", ALC269_FIXUP_SKU_IGNORE),
 	SND_PCI_QUIRK(0x17aa, 0x215e, "Thinkpad L512", ALC269_FIXUP_SKU_IGNORE),
 	SND_PCI_QUIRK(0x17aa, 0x21b8, "Thinkpad Edge 14", ALC269_FIXUP_SKU_IGNORE),


### PR DESCRIPTION
The Gigabyte BRIX BXBT-2707 is a mini-PC with Realtek ALC283 HDA,
exposing a single headset jack.

However, the default pin config information only suggests
that one pin is connected: a HP out jack (pin 0x21, default
config 0x04211010).

The microphone input is behind pin 0x19, which has default
config 0x411111f0 (i.e. unused), so it does not show up in
userspace, and no microphone input is possible via the headset.

Override the pin config so that the headset mic can be used.

[rearranged the fixup entry position by tiwai]

Signed-off-by: Daniel Drake drake@endlessm.com
Signed-off-by: Takashi Iwai tiwai@suse.de

https://github.com/endlessm/eos-shell/issues/2932
