### PR TITLE
drm/exynos: fix plane-framebuffer linkage

### DIFF
--- a/drivers/gpu/drm/exynos/exynos_drm_crtc.c
+++ b/drivers/gpu/drm/exynos/exynos_drm_crtc.c
@@ -158,17 +158,9 @@ exynos_drm_crtc_mode_set(struct drm_crtc *crtc, struct drm_display_mode *mode,
 		crtc_uv = exynos_crtc->underscan_vborder;
 	}
 
-	ret = exynos_plane_mode_set(plane, crtc, crtc->primary->fb,
+	return exynos_plane_mode_set(plane, crtc, crtc->primary->fb,
 		crtc_uh, crtc_uv, crtc_w, crtc_h,
 		x, y, crtc_w, crtc_h);
-	if (ret)
-		return ret;
-
-	plane->crtc = crtc;
-	plane->fb = crtc->primary->fb;
-	drm_framebuffer_reference(plane->fb);
-
-	return 0;
 }
 
 static int exynos_drm_crtc_mode_set_commit(struct drm_crtc *crtc, int x, int y,

--- a/drivers/gpu/drm/exynos/exynos_drm_plane.c
+++ b/drivers/gpu/drm/exynos/exynos_drm_plane.c
@@ -139,6 +139,14 @@ int exynos_plane_mode_set(struct drm_plane *plane, struct drm_crtc *crtc,
 			overlay->crtc_x, overlay->crtc_y,
 			overlay->crtc_width, overlay->crtc_height);
 
+	if (plane->fb)
+		drm_framebuffer_unreference(plane->fb);
+
+	drm_framebuffer_reference(fb);
+
+	plane->fb = fb;
+	plane->crtc = crtc;
+
 	exynos_drm_crtc_plane_mode_set(crtc, overlay);
 
 	return 0;


### PR DESCRIPTION
Pageflipping currently causes some inconsistencies that lead to
crashes. Just run an app that causes a CRTC pageflip in a raw X session
and check that it exits cleanly and can be restarted - you'll see
crashes like:
 Unable to handle kernel NULL pointer dereference at virtual address 00000334
 PC is at exynos_drm_crtc_plane_commit+0x20/0x40
 LR is at exynos_drm_crtc_plane_commit+0x20/0x40
 [<c03749b4>](exynos_drm_crtc_plane_commit) from [<c03741bc>](exynos_drm_crtc_commit+0x44/0x70)
 [<c03741bc>](exynos_drm_crtc_commit) from [<c03743a0>](exynos_drm_crtc_mode_set_commit.isra.2+0xb4/0xc4)
 [<c03743a0>](exynos_drm_crtc_mode_set_commit.isra.2) from [<c03744f4>](exynos_drm_crtc_page_flip+0x140/0x1a8)
 [<c03744f4>](exynos_drm_crtc_page_flip) from [<c036b20c>](drm_mode_page_flip_ioctl+0x224/0x2dc)
 [<c036b20c>](drm_mode_page_flip_ioctl) from [<c035c324>](drm_ioctl+0x338/0x4fc)

These crashes happen because drm_plane_force_disable has previously set
plane->crtc to NULL.

When drm_mode_page_flip_ioctl() is used to flip another framebuffer
onto the primary plane, crtc->primary->fb is correctly updated (this is
a virtual plane created by plane_helper), but plane->fb is not (this
plane is the real one, created by exynos_drm_crtc_create).

We then come to handle rmfb of the backbuffer, which the "real" primary
plane is incorrectly pointing at. So drm_framebuffer_remove() decides that
the buffer is actually active on a plane and force-disables the plane.

Ensuring that plane->fb is kept up-to-date solves that issue, but
exposes a reference counting problem. Now we see crashes when rmfb is
called on the front-buffer, because the rmfb code expects to drop 3
references here, and there are only 2.

That can be fixed by adopting the reference management found in omapdrm:
Framebuffer references are not taken directly in crtc mode_set context,
but rather in the context of updating the plane, which also covers
flips. Like omapdrm we also unreference the old framebuffer here.

Signed-off-by: Daniel Drake drake@endlessm.com

https://github.com/endlessm/eos-shell/issues/3449
