### PR TITLE
exynos-drm: enable QoS to avoid visual glitches at high resolutions

### DIFF
--- a/arch/arm/mach-exynos/exynos.c
+++ b/arch/arm/mach-exynos/exynos.c
@@ -355,6 +355,50 @@ static void __init exynos_dt_fixup(void)
 	of_fdt_limit_memory(8);
 }
 
+/* Undocumented Exynos4412 QoS registers. Needed to prioritize RAM accesses
+ * from display controllers in the face of bus competition.
+ * In particular, we have seen that the GPU can easily saturate memory
+ * bandwidth and cause underflows for the display controllers (visual glitches
+ * appear at 1080p@60Hz).
+ *
+ * There is a higher-than-expected GPU performance degradation when this QoS
+ * is applied. And actually, testing at 640x480 where bus competition should
+ * be minimal, the GPU performance loss is still equal. Therefore this does
+ * not seem to be working as QoS, instead it just makes the GPU slow down to
+ * the point where it can't saturate memory bandwidth. Sigh.
+ * Anyway, it avoids the glitches.
+ *
+ * The best documentation of these registers can be found from an old Android
+ * code drop, as below:
+ *
+ * QOSAC_GDL (0x11600400)
+ * [0] Image Block: "1" Full Resource, "0" Tidemark
+ * [1] TV Block: "1" Full Resource, "0" Tidemark
+ * [2] G3D Block: "1" Full Resource, "0" Tidemark
+ * [3] MFC_L Block: "1" Full Resource, "0" Tidemark
+ *
+ * QOSAC_GDR (0x11200400)
+ * [0] CAM Block: "1" Full Resource, "0" Tidemark
+ * [1] LCD0 Block: "1" Full Resource, "0" Tidemark
+ * [2] LCD1 Block: "1" Full Resource, "0" Tidemark
+ * [3] FSYS Block: "1" Full Resource, "0" Tidemark
+ * [4] MFC_R Block: "1" Full Resource, "0" Tidemark
+ * [5] MAUDIO Block: "1" Full Resource, "0" Tidemark
+ *
+ * We have no docs for the AC registers (offset +4 from the above).
+ * We currently only write to the left bus registers.
+*/
+void exynos4412_qos(u8 tm, u8 ac)
+{
+	void __iomem *qos_gdl_base = ioremap(0x11600400, 8);
+	if (!qos_gdl_base)
+		return;
+
+	__raw_writel(tm, qos_gdl_base);
+	__raw_writel(ac, qos_gdl_base + 4);
+	iounmap(qos_gdl_base);
+}
+
 DT_MACHINE_START(EXYNOS_DT, "SAMSUNG EXYNOS ODROID (Flattened Device Tree)")
 	/* Maintainer: Thomas Abraham <thomas.abraham@linaro.org> */
 	/* Maintainer: Kukjin Kim <kgene.kim@samsung.com> */

--- a/drivers/gpu/drm/exynos/exynos_drm_dpi.c
+++ b/drivers/gpu/drm/exynos/exynos_drm_dpi.c
@@ -211,7 +211,24 @@ static void exynos_dpi_dpms(struct exynos_drm_display *display, int mode)
 	ctx->dpms_mode = mode;
 }
 
+static void exynos_dpi_mode_set(struct exynos_drm_display *display,
+				struct drm_display_mode *mode)
+{
+	/* At 1280x1024@60Hz and higher there is not enough memory bandwidth
+	 * available for the display controller when the GPU is busy. So we
+	 * apply a "QoS" scheme.
+	 * I found these numbers through guesswork. The GPU performance is
+	 * degraded by about 30%, but there are no flickers.
+	 */
+	if (mode->clock >= 135000)
+		exynos4412_qos(3, 3);
+	else
+		exynos4412_qos(0, 0);
+}
+
+
 static struct exynos_drm_display_ops exynos_dpi_display_ops = {
+	.mode_set = exynos_dpi_mode_set,
 	.create_connector = exynos_dpi_create_connector,
 	.dpms = exynos_dpi_dpms
 };

--- a/drivers/gpu/drm/exynos/exynos_drm_drv.h
+++ b/drivers/gpu/drm/exynos/exynos_drm_drv.h
@@ -60,6 +60,8 @@ enum exynos_drm_output_type {
 	EXYNOS_DISPLAY_TYPE_VIDI,
 };
 
+extern void exynos4412_qos(u8 tm, u8 ac);
+
 /*
  * Exynos drm common overlay structure.
  *

--- a/drivers/gpu/drm/exynos/exynos_hdmi.c
+++ b/drivers/gpu/drm/exynos/exynos_hdmi.c
@@ -1655,6 +1655,21 @@ static void hdmi_v14_mode_apply(struct hdmi_context *hdata)
 
 static void hdmi_mode_apply(struct hdmi_context *hdata)
 {
+	struct drm_display_mode *m = &hdata->current_mode;
+
+	/* At 1080p at 60Hz, there is not enough memory bandwidth available
+	 * for the display controller when the GPU is busy. So we apply a
+	 * "QoS" scheme.
+	 * According to Samsung, this should result in image, G3D, and MFC
+	 * having the same priority, and when bus competition occurs, the
+	 * TV(HDMI) has the highest priority.
+	 * GPU performance drops by about 10%.
+	 */
+	if (m->clock == 148500 && drm_mode_vrefresh(m) > 50)
+		exynos4412_qos(7, 2);
+	else
+		exynos4412_qos(0, 0);
+
 	if (hdata->type == HDMI_TYPE13)
 		hdmi_v13_mode_apply(hdata);
 	else


### PR DESCRIPTION
At the 800MHz MPLL / 400MHz memory bus / 200MHz AXI bus configuration,
the Exynos4412 is unable to reliably scan out a 1080p@60Hz image over HDMI
when the GPU is in use.

Enable some QoS functionality (or rather, simple GPU slowdown) to
avoid this problem. And do the same for VGA for the display modes where
this problem can be seen there.

https://github.com/endlessm/eos-shell/issues/3525
