### PR TITLE
Sqwerty: fix eMMC reboot

### DIFF
--- a/arch/arm/boot/dts/exynos4412-sqwerty.dts
+++ b/arch/arm/boot/dts/exynos4412-sqwerty.dts
@@ -99,7 +99,6 @@
 		samsung,dw-mshc-ciu-div = <3>;
 		samsung,dw-mshc-sdr-timing = <2 3>;
 		samsung,dw-mshc-ddr-timing = <1 2>;
-		samsung,dw-mshc-hwreset-gpio = <&gpk1 2 1>;
 
 		slot@0 {
 			reg = <0>;
@@ -433,13 +432,6 @@
 					regulator-min-microvolt = <2000000>;
 					regulator-max-microvolt = <2000000>;
 					regulator-always-on;
-				};
-
-				buck8_reg: BUCK8 {
-					regulator-name = "BUCK8_2.85V";
-					regulator-min-microvolt = <2850000>;
-					regulator-max-microvolt = <2850000>;
-					regulator-always-on; /* Might be used for eMMC in hardware rework. Remove this otherwise. */
 				};
 			};
 		};


### PR DESCRIPTION
Newer version of the board do have GPK1[2] connected to the reset pin
but that does not seem to be enough to reset the eMMC chip, causing
uboot to fail to load upon reboot.

Instead, cycling the BUCK8 power supply over reboot seems to be
the intended way for eMMC reset to happen.

The BUCK8 hardware control ENB8 is connected to GPK0[2], and
uboot already configures this for us. It is pulled to high during
uboot initialization (enabling eMMC power), but the hardware default
at reset is that it is pulled low. The result here is that GPK0[2]
pulses ENB8 low during reboot, which causes the eMMC chip to be
powered down and then on again, completing the reset.

All that is left to do is to make sure that ENB8 is used (the
hardware default).
The previous Linux regulator definition was turning BUCK8 on always,
regardless of ENB8 status, and the PMIC does not get reset during
reboot.

Drop the BUCK8 regulator definition so that the hardware default
behaviour is used, enabling the reset sequence as above.

https://github.com/endlessm/eos-shell/issues/3513
