### PR TITLE
x86/reboot: Use bios reboot for GIGABYTE BRIX BXBT-2807

### DIFF
--- a/arch/x86/kernel/reboot.c
+++ b/arch/x86/kernel/reboot.c
@@ -366,6 +366,16 @@ static struct dmi_system_id __initdata reboot_dmi_table[] = {
 		},
 	},
 
+	/* GIGABYTE */
+	{	/* Workaround hard disk crash on ACPI reboot */
+		.callback = set_bios_reboot,
+		.ident = "GIGABYTE BRIX BXBT-2807",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "GIGABYTE"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "GB-BXBT-2807"),
+		},
+	},
+
 	/* Hewlett-Packard */
 	{	/* Handle problems with rebooting on HP laptops */
 		.callback = set_bios_reboot,


### PR DESCRIPTION
Using ACPI, the hard disk crashes on reboot. This seems to be avoided
when using the BIOS to reboot.

[endlessm/eos-shell#3835]
