### PR TITLE
Input: 18042 - add Gigabyte P35v1 to Elantech touchpad fix

### DIFF
--- a/drivers/input/serio/i8042-x86ia64io.h
+++ b/drivers/input/serio/i8042-x86ia64io.h
@@ -690,6 +690,13 @@ static const struct dmi_system_id __initconst i8042_dmi_dritek_table[] = {
  */
 static const struct dmi_system_id __initconst i8042_dmi_kbdreset_table[] = {
 	{
+		/* Gigabyte P35 - Elantech touchpad */
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "GIGABYTE"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "P35"),
+		},
+	},
+	{
 		/* Gigabyte P35 v2 - Elantech touchpad */
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "GIGABYTE"),


### PR DESCRIPTION
Commit 209285518bef4b3 added a fix for Gigabyte P35V2, but not P35V1. This adds
that model to the list which recieve the fix.

[endlessm/eos-shell#4607]