### PR TITLE
Revert "UBUNTU: SAUCE: Switch VLV/BYT to use i915_bdw."

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -383,7 +383,9 @@ static const struct intel_device_info intel_broadwell_m_info = {
 	INTEL_IVB_M_IDS(&intel_ivybridge_m_info),	\
 	INTEL_IVB_D_IDS(&intel_ivybridge_d_info),	\
 	INTEL_HSW_D_IDS(&intel_haswell_d_info), \
-	INTEL_HSW_M_IDS(&intel_haswell_m_info)
+	INTEL_HSW_M_IDS(&intel_haswell_m_info), \
+	INTEL_VLV_M_IDS(&intel_valleyview_m_info),	\
+	INTEL_VLV_D_IDS(&intel_valleyview_d_info)
 
 static const struct pci_device_id pciidlist[] = {		/* aka */
 	INTEL_PCI_IDS,

--- a/ubuntu/i915/i915_drv.c
+++ b/ubuntu/i915/i915_drv.c
@@ -288,8 +288,6 @@ static const struct intel_device_info intel_broadwell_m_info = {
  * PCI ID matches, otherwise we'll use the wrong info struct above.
  */
 #define INTEL_PCI_IDS \
-	INTEL_VLV_M_IDS(&intel_valleyview_m_info),      \
-	INTEL_VLV_D_IDS(&intel_valleyview_d_info),      \
 	INTEL_BDW_M_IDS(&intel_broadwell_m_info),	\
 	INTEL_BDW_D_IDS(&intel_broadwell_d_info)
 


### PR DESCRIPTION
This reverts commit 713b616949f9ed8f903458c5284e1351d378e222.
The i915_bdw driver takes 1 second longer to load during boot (1.7s vs 0.7s).

https://github.com/endlessm/eos-shell/issues/4701