### PR TITLE
ACPI / video: Change the default for video.use_native_backlight to 1

### DIFF
--- a/drivers/acpi/video.c
+++ b/drivers/acpi/video.c
@@ -85,7 +85,7 @@ module_param(allow_duplicates, bool, 0644);
  * For Windows 8 systems: used to decide if video module
  * should skip registering backlight interface of its own.
  */
-static int use_native_backlight_param = -1;
+static int use_native_backlight_param = 1;
 module_param_named(use_native_backlight, use_native_backlight_param, int, 0444);
 static bool use_native_backlight_dmi = false;
 


### PR DESCRIPTION
Now that we're hoping to have resolved all of the problems with
video.use_native_backlight=1, make that the default at last.

Link: http://marc.info/?l=linux-acpi&m=139716088401106&w=2
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>

https://github.com/endlessm/eos-shell/issues/4728