### PR TITLE
r8169: Match new BIOS version

### DIFF
--- a/drivers/net/ethernet/realtek/r8169.c
+++ b/drivers/net/ethernet/realtek/r8169.c
@@ -6979,7 +6979,7 @@ static int rtl_flag_use_pio(const struct dmi_system_id *id)
 static struct dmi_system_id rtl_dmi_table[] __initdata = {
 	{
 		rtl_flag_use_pio, "Quanta NL3",
-		{ DMI_MATCH(DMI_BIOS_VERSION, "NL3.86A.0030.A7") },
+		{ DMI_MATCH(DMI_BIOS_VERSION, "NL3.86A.E030.C4") },
 		NULL,
 	},
 };


### PR DESCRIPTION
Match new BIOS version that fixes #4646

[endlessm/eos-shell#4648]