### PR TITLE
x86/platform: add WiFi media button support for NL3

### DIFF
--- a/drivers/platform/x86/classmate-laptop.c
+++ b/drivers/platform/x86/classmate-laptop.c
@@ -1049,6 +1049,8 @@ static int cmpc_keys_codes[] = {
 	KEY_CAMERA,
 	KEY_BACK,
 	KEY_FORWARD,
+	KEY_UNKNOWN,
+	KEY_WLAN, /* NL3: 0x8b (press), 0x9b (release) */
 	KEY_MAX
 };
 


### PR DESCRIPTION
The WiFi media button on the NL3 reports keycodes 0x8b and 0x9b to the
platfrom driver. Fix the classmate-laptop driver to support these codes.

[endlessm/eos-shell#4792]