### PR TITLE
alps: Increase pressure on JWM machines

### DIFF
--- a/drivers/input/mouse/alps.h
+++ b/drivers/input/mouse/alps.h
@@ -164,6 +164,7 @@ struct alps_data {
 };
 
 #define ALPS_QUIRK_TRACKSTICK_BUTTONS	1 /* trakcstick buttons in trackstick packet */
+#define ALPS_QUIRK_LOW_PRESSURE		2 /* pressure values need to be scaled */
 
 #ifdef CONFIG_MOUSE_PS2_ALPS
 int alps_detect(struct psmouse *psmouse, bool set_properties);


### PR DESCRIPTION
For some reason, the input pressure we're seeing is far below the spec'd
value. We think it's a hardware calibration or a physical construction
issue, but since we don't have as much power over the JWM machines
ordered from Quanta, let's quirkify this for now.

Signed-off-by: Jasper St. Pierre <jstpierre@mecheye.net>

[endlessm/eos-shell#4774]