### PR TITLE
drm/i915: do not force VDD when switching panel off

### DIFF
--- a/drivers/gpu/drm/i915/intel_dp.c
+++ b/drivers/gpu/drm/i915/intel_dp.c
@@ -1249,9 +1249,7 @@ void ironlake_edp_panel_off(struct intel_dp *intel_dp)
 	WARN(!intel_dp->want_panel_vdd, "Need VDD to turn off panel\n");
 
 	pp = ironlake_get_pp_control(intel_dp);
-	/* We need to switch off panel power _and_ force vdd, for otherwise some
-	 * panels get very unhappy and cease to work. */
-	pp &= ~(POWER_TARGET_ON | EDP_FORCE_VDD | PANEL_POWER_RESET | EDP_BLC_ENABLE);
+	pp &= ~(POWER_TARGET_ON | PANEL_POWER_RESET | EDP_BLC_ENABLE);
 
 	pp_ctrl_reg = _pp_ctrl_reg(intel_dp);
 


### PR DESCRIPTION
This is a workaround to fix the black screen problem and i915 driver
crashing on the NL3 laptop when switching to an external display. This
fix is to be intended as a dirty hack before upgrading to a new kernel
where it is possible to include the real fix (torvalds/linux@83b8459)

[endlessm/eos-shell#4649]