### PR TITLE
ALSA/hda: add new fixup for the automute on NL3 laptop

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -4252,6 +4252,24 @@ static void alc290_fixup_mono_speakers(struct hda_codec *codec,
 /* for dell wmi mic mute led */
 #include "dell_wmi_helper.c"
 
+static void alc269vc_nl3_fixup_automute(struct hda_codec *codec,
+					const struct hda_fixup *fix, int action)
+{
+	unsigned int val;
+	struct snd_kcontrol *kctl;
+	struct snd_ctl_elem_value *uctl;
+
+	kctl = snd_hda_find_mixer_ctl(codec, "Auto-Mute Mode");
+	if (!kctl)
+		return;
+	uctl = kzalloc(sizeof(*uctl), GFP_KERNEL);
+	if (!uctl)
+		return;
+	uctl->value.enumerated.item[0] = 1;
+	kctl->put(kctl, uctl);
+	kfree(uctl);
+}
+
 enum {
 	ALC269_FIXUP_SONY_VAIO,
 	ALC275_FIXUP_SONY_VAIO_GPIO2,
@@ -4316,6 +4334,7 @@ enum {
 	ALC255_FIXUP_DELL_WMI_MIC_MUTE_LED,
 	ALC283_FIXUP_BXBT2807_MIC,
 	ALC269VC_FIXUP_NL3_SECOND_JACK,
+	ALC269VC_FIXUP_NL3_AUTOMUTE,
 };
 
 static const struct hda_fixup alc269_fixups[] = {
@@ -4763,8 +4782,13 @@ static const struct hda_fixup alc269_fixups[] = {
 			{ 0x1a, 0x222140af },
 			{ },
 		},
+		.chained = true,
+		.chain_id = ALC269VC_FIXUP_NL3_AUTOMUTE
 	},
-
+	[ALC269VC_FIXUP_NL3_AUTOMUTE] = {
+		.type = HDA_FIXUP_FUNC,
+		.v.func = alc269vc_nl3_fixup_automute,
+	},
 };
 
 static const struct snd_pci_quirk alc269_fixup_tbl[] = {


### PR DESCRIPTION
To have both the audio jacks working at the same time on the NL3 laptop
we need to force ALSA to set the 'Auto-Mute Mode' mixer control to
'Speaker only'.  This patch adds a new fixup specific for the NL3 laptop
to force this setting.

[endlessm/eos-shell#4990]