### PR TITLE
pinctrl: cherryview: Do not mask all interrupts on probe

### DIFF
--- a/drivers/pinctrl/intel/pinctrl-cherryview.c
+++ b/drivers/pinctrl/intel/pinctrl-cherryview.c
@@ -1461,8 +1461,7 @@ static int chv_gpio_probe(struct chv_pinctrl *pctrl, int irq)
 		offset += range->npins;
 	}
 
-	/* Mask and clear all interrupts */
-	chv_writel(0, pctrl->regs + CHV_INTMASK);
+	/* Clear all interrupts */
 	chv_writel(0xffff, pctrl->regs + CHV_INTSTAT);
 
 	ret = gpiochip_irqchip_add(chip, &chv_gpio_irqchip, 0,


### PR DESCRIPTION
BIOS/platform may use some of the pins by themselves, such as providing SCI
(System Control Interrupt) from the embedded controller. The driver masks
all interrupts at probe time which prevents those pins from triggering
interrupts properly.

Fix this by not masking all interrupts at probe -- it should be enough just
to clear the status register.

Reported-by: Yu C Chen <yu.c.chen@intel.com>
Signed-off-by: Mika Westerberg <mika.westerberg@linux.intel.com>

This patch fixes the problems with the ASUS E202SA brightness keys. It
was not included upstream and the relevant discussion can be found at
https://lkml.org/lkml/2015/5/22/111

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5342]