### PR TITLE
platform/x86: Add ASUS Wireless Radio Control driver

### DIFF
--- a/drivers/platform/x86/Kconfig
+++ b/drivers/platform/x86/Kconfig
@@ -561,6 +561,21 @@ config EEEPC_WMI
 	  If you have an ACPI-WMI compatible Eee PC laptop (>= 1000), say Y or M
 	  here.
 
+config ASUS_WRC
+	tristate "ASUS Wireless Radio Control Driver"
+	depends on ACPI
+	depends on INPUT
+	select INPUT_SPARSEKMAP
+	---help---
+	  This is a driver for the wireless radio control (airplane mode hotkey)
+	  found on some Asus laptops, also known as ATK4002 or ASHS.
+
+	  Say Y or M here if you have an ASUS notebook with an airplane mode
+	  hotkey.
+
+	  If you choose to compile this driver as a module the module will be
+	  called asus-wrc.
+
 config ACPI_WMI
 	tristate "WMI"
 	depends on ACPI

--- a/drivers/platform/x86/Makefile
+++ b/drivers/platform/x86/Makefile
@@ -5,6 +5,7 @@
 obj-$(CONFIG_ASUS_LAPTOP)	+= asus-laptop.o
 obj-$(CONFIG_ASUS_WMI)		+= asus-wmi.o
 obj-$(CONFIG_ASUS_NB_WMI)	+= asus-nb-wmi.o
+obj-$(CONFIG_ASUS_WRC)		+= asus-wrc.o
 obj-$(CONFIG_EEEPC_LAPTOP)	+= eeepc-laptop.o
 obj-$(CONFIG_EEEPC_WMI)		+= eeepc-wmi.o
 obj-$(CONFIG_MSI_LAPTOP)	+= msi-laptop.o

--- a/drivers/platform/x86/asus-wrc.c
+++ b/drivers/platform/x86/asus-wrc.c
@@ -1,0 +1,123 @@
+/*
+ * Asus Wireless Radio Control Driver
+ *
+ * Copyright (C) 2015 Endless Mobile, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/types.h>
+#include <linux/acpi.h>
+#include <linux/input.h>
+#include <linux/input/sparse-keymap.h>
+
+#define ASUS_WRC_MODULE_NAME "Asus Wireless Radio Control Driver"
+
+struct asus_wrc_data {
+	struct input_dev *inputdev;
+};
+
+static const struct key_entry asus_wrc_keymap[] = {
+	{ KE_KEY, 0x88, { KEY_RFKILL } },
+	{ KE_END, 0 }
+};
+
+static void asus_wrc_notify(struct acpi_device *device, u32 event)
+{
+	struct asus_wrc_data *data = acpi_driver_data(device);
+
+	pr_debug("event=0x%X\n", event);
+
+	if (!sparse_keymap_report_event(data->inputdev, event, 1, true))
+		pr_info("Unknown ASHS event: 0x%X\n", event);
+}
+
+static int asus_wrc_add(struct acpi_device *device)
+{
+	struct asus_wrc_data *data;
+	int err = -ENOMEM;
+
+	pr_info(ASUS_WRC_MODULE_NAME"\n");
+
+	data = kzalloc(sizeof(struct asus_wrc_data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->inputdev = input_allocate_device();
+	if (!data->inputdev)
+		goto free_driver_data;
+
+	data->inputdev->name = "Asus Wireless Radio Control";
+	data->inputdev->phys = "asus-wrc/input0";
+	data->inputdev->id.bustype = BUS_HOST;
+	data->inputdev->dev.parent = &device->dev;
+	set_bit(EV_REP, data->inputdev->evbit);
+
+	err = sparse_keymap_setup(data->inputdev, asus_wrc_keymap, NULL);
+	if (err)
+		goto free_inputdev;
+
+	err = input_register_device(data->inputdev);
+	if (err)
+		goto free_keymap;
+
+	device->driver_data = data;
+	return 0;
+
+free_keymap:
+	sparse_keymap_free(data->inputdev);
+free_inputdev:
+	input_free_device(data->inputdev);
+free_driver_data:
+	kfree(data);
+
+	return err;
+}
+
+static int asus_wrc_remove(struct acpi_device *device)
+{
+	struct asus_wrc_data *data = acpi_driver_data(device);
+
+	pr_info("Removing "ASUS_WRC_MODULE_NAME"\n");
+
+	if (data) {
+		if (data->inputdev) {
+			sparse_keymap_free(data->inputdev);
+			input_unregister_device(data->inputdev);
+			data->inputdev = NULL;
+		}
+
+		kfree(data);
+		data = NULL;
+	}
+	return 0;
+}
+
+static const struct acpi_device_id device_ids[] = {
+	{"ATK4002", 0},
+	{"", 0},
+};
+MODULE_DEVICE_TABLE(acpi, device_ids);
+
+static struct acpi_driver asus_wrc_driver = {
+	.name = ASUS_WRC_MODULE_NAME,
+	.class = "hotkey",
+	.ids = device_ids,
+	.ops = {
+		.add = asus_wrc_add,
+		.remove = asus_wrc_remove,
+		.notify = asus_wrc_notify,
+	},
+};
+module_acpi_driver(asus_wrc_driver);
+
+MODULE_DESCRIPTION(ASUS_WRC_MODULE_NAME);
+MODULE_AUTHOR("João Paulo Rechi Vita <jprvita@gmail.com>");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Some ASUS notebooks like the E202SA have a separate ACPI for
notifications from the airplane mode hotkey. This device is called ASHS
in the DSDT and its ACPI _HID is ATK4002.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5455]