### PR TITLE
ALSA/hda: add fixup to not treat second headphone jack as line out

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -5081,6 +5081,8 @@ static const struct hda_fixup alc269_fixups[] = {
 	[ALC269VC_FIXUP_NL3_AUTOMUTE] = {
 		.type = HDA_FIXUP_FUNC,
 		.v.func = alc269vc_nl3_fixup_automute,
+		.chained = true,
+		.chain_id = ALC269_FIXUP_PINCFG_NO_HP_TO_LINEOUT
 	},
 };
 


### PR DESCRIPTION
The hda auto parser has a fixup that is enabled by default to
try to detect when a supposed headphone jack is actually a
line out jack. The change to set the other headphone jack to
a 'Dock Headphone Jack' changed the sequence number of that
jack to the correct value of 0xf; however, the front jack still
gets an incorrect value from the hardware. This makes the auto
parser fixup conclude the front jack is not really a headphone
jack.

Disable that erroneous fixup to allow more than one headphone
jack to be detected without changing one to a line out jack.

[endlessm/eos-shell#5358]