### PR TITLE
rfkill: Copy "all" global state to other types

### DIFF
--- a/net/rfkill/core.c
+++ b/net/rfkill/core.c
@@ -341,7 +341,14 @@ static void __rfkill_switch_all(const enum rfkill_type type, bool blocked)
 {
 	struct rfkill *rfkill;
 
-	rfkill_global_states[type].cur = blocked;
+	if (type == RFKILL_TYPE_ALL) {
+		enum rfkill_type i;
+		for (i = 0; i < NUM_RFKILL_TYPES; i++)
+			rfkill_global_states[i].cur = blocked;
+	} else {
+		rfkill_global_states[type].cur = blocked;
+	}
+
 	list_for_each_entry(rfkill, &rfkill_list, node) {
 		if (rfkill->type != type && type != RFKILL_TYPE_ALL)
 			continue;


### PR DESCRIPTION
When switching the state of all RFKill switches of type all we need to
replicate the RFKILL_TYPE_ALL global state to all the other types global
state, so it is used to initialize persistent RFKill switches on
initialization.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5598]