### PR TITLE
PCI: disable MSI on problematic Asus platforms

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2220,6 +2220,35 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_VIA, PCI_DEVICE_ID_VIA_VT3351, quirk_disab
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_VIA, PCI_DEVICE_ID_VIA_VT3364, quirk_disable_all_msi);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_VIA, PCI_DEVICE_ID_VIA_8380_0, quirk_disable_all_msi);
 
+static const struct dmi_system_id broken_msi_table[] = {
+	{
+		/* Asus laptop with PCIe AER spam when MSI is enabled. */
+		.ident = "ASUSTeK COMPUTER INC. X456UA",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X456UA"),
+		},
+	},
+	{
+		/* Asus laptop with PCIe AER spam when MSI is enabled. */
+		.ident = "ASUSTeK COMPUTER INC. X456UF",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X456UF"),
+		},
+	},
+	{}
+};
+static void quirk_disable_all_msi2(struct pci_dev *dev)
+{
+	if (!dmi_check_system(broken_msi_table))
+		return;
+
+	pci_no_msi();
+	dev_warn(&dev->dev, "MSI disabled on this platform due to quirk\n");
+}
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_all_msi2);
+
 /* Disable MSI on chipsets that are known to not support it */
 static void quirk_disable_msi(struct pci_dev *dev)
 {


### PR DESCRIPTION
In the default configuration, these Asus laptops log a lot of PCIe
AER spam, and this potentially also causes some system instability:

 pcieport 0000:00:1c.5: AER: Corrected error received: id=00e5
 pcieport 0000:00:1c.5: PCIe Bus Error: severity=Corrected,
type=Physical Layer, id=00e5(Receiver ID)
 pcieport 0000:00:1c.5:   device [8086:9d15] error status/mask=00000001/00002000
 pcieport 0000:00:1c.5:    [ 0] Receiver Error         (First)
 pcieport 0000:00:1c.5: AER: Corrected error received: id=00e5
 pcieport 0000:00:1c.5: PCIe Bus Error: severity=Corrected,
type=Physical Layer, id=00e5(Receiver ID)
 pcieport 0000:00:1c.5:   device [8086:9d15] error status/mask=00000001/00002000
 pcieport 0000:00:1c.5:    [ 0] Receiver Error         (First)
 pcieport 0000:00:1c.5: AER: Corrected error received: id=00e5
 pcieport 0000:00:1c.5: can't find device of ID00e5

Booting with pci=nomsi or pcie_aspm=off avoids the problem.

In this case, 00:1c.5 is a PCIe bridge with the wifi card the
other side. However, setting no_msi on that pci_dev is not enough to
kill the spam. So lets just disable MSI on the whole platform.

[endlessm/eos-shell#5676]