### PR TITLE
PCI: disable MSI on Asus X555UB

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2237,6 +2237,14 @@ static const struct dmi_system_id broken_msi_table[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "X456UF"),
 		},
 	},
+	{
+		/* Asus laptop with PCIe AER spam when MSI is enabled. */
+		.ident = "ASUSTeK COMPUTER INC. X555UB",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X555UB"),
+		},
+	},
 	{}
 };
 static void quirk_disable_all_msi2(struct pci_dev *dev)


### PR DESCRIPTION
This laptop has a lot of PCI express error spam in dmesg until pci=nomsi
is used.

pcieport 0000:00:1c.5: AER: Corrected error received: id=00e5
pcieport 0000:00:1c.5: PCIe Bus Error: severity=Corrected, type=Physical Layer, id=00e5(Receiver ID)
pcieport 0000:00:1c.5:   device [8086:9d15] error status/mask=00000001/00002000
pcieport 0000:00:1c.5:    [ 0] Receiver Error

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5745]