### PR TITLE
Fix compiler warning

### DIFF
--- a/arch/x86/kernel/tsc.c
+++ b/arch/x86/kernel/tsc.c
@@ -1161,7 +1161,7 @@ static const struct dmi_system_id tsc_quirk_table[] = {
 	{}
 };
 
-static int check_tsc_quirks(void)
+static void check_tsc_quirks(void)
 {
 	dmi_check_system(tsc_quirk_table);
 }


### PR DESCRIPTION
I've introduced the following warning when fixing #5687 :(
```
arch/x86/kernel/tsc.c: In function ‘check_tsc_quirks’:
arch/x86/kernel/tsc.c:1167:1: warning: no return statement in function returning non-void [-Wreturn-type]
```

@dsd, @carlocaione, @magcius Could one of you guys please review and merge this one?