### PR TITLE
sound/hda: Add pin quirk for ASUS X540SA/X555UB headset mic

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -5203,6 +5203,7 @@ static const struct hda_fixup alc269_fixups[] = {
 		.type = HDA_FIXUP_PINS,
 		.v.pins = (const struct hda_pintbl[]) {
 			{ 0x13, 0x90a60160 }, /* use as internal mic */
+			{ 0x19, 0x04a11120 }, /* use as headset mic, without its own jack detect */
 			{ }
 		},
 		.chained = true,


### PR DESCRIPTION
These laptops need a different pin value on pin 0x19 for the headset
microphone to work. Unfortunatelly I could not find a way to make jack
detection for the headset microphone to work.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5769]
[endlessm/eos-shell#5770]