### PR TITLE
Input: i8042 - don't run self test on Asus X455LAB

### DIFF
--- a/drivers/input/serio/i8042.c
+++ b/drivers/input/serio/i8042.c
@@ -24,6 +24,7 @@
 #include <linux/platform_device.h>
 #include <linux/i8042.h>
 #include <linux/slab.h>
+#include <linux/dmi.h>
 
 #include <asm/io.h>
 
@@ -133,6 +134,7 @@ static bool i8042_kbd_irq_registered;
 static bool i8042_aux_irq_registered;
 static unsigned char i8042_suppress_kbd_ack;
 static struct platform_device *i8042_platform_device;
+static bool i8042_noselftest;
 
 static irqreturn_t i8042_interrupt(int irq, void *dev_id);
 static bool (*i8042_platform_filter)(unsigned char data, unsigned char str,
@@ -884,6 +886,13 @@ static int i8042_controller_selftest(void)
 	int i = 0;
 
 	/*
+	 * On some hardware just running the self test causes problems.
+	 * In that case, don't run the test and just assume success.
+	 */
+	if (i8042_noselftest)
+		return 0;
+
+	/*
 	 * We try this 5 times; on some really fragile systems this does not
 	 * take the first time...
 	 */
@@ -1496,6 +1505,16 @@ static int i8042_remove(struct platform_device *dev)
 	return 0;
 }
 
+static const struct dmi_system_id i8042_dmi_noselftest_table[] __initconst = {
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X455LAB"),
+		},
+	},
+	{}
+};
+
 static struct platform_driver i8042_driver = {
 	.driver		= {
 		.name	= "i8042",
@@ -1513,6 +1532,8 @@ static int __init i8042_init(void)
 	int err;
 
 	dbg_init();
+	if (dmi_check_system(i8042_dmi_noselftest_table))
+		i8042_noselftest = true;
 
 	err = i8042_platform_init();
 	if (err)


### PR DESCRIPTION
On this model, any time the self test command is sent to the
i8042 controller the trackpad stops sending data. Never send the
self test command when this model is detected with DMI.

[endlessm/eos-shell#5681]