### PR TITLE
Revert "rtlwifi: Remove the clear interrupt routine from all drivers"

### DIFF
--- a/drivers/net/wireless/rtlwifi/rtl8188ee/hw.c
+++ b/drivers/net/wireless/rtlwifi/rtl8188ee/hw.c
@@ -1354,11 +1354,27 @@ void rtl88ee_set_qos(struct ieee80211_hw *hw, int aci)
 	}
 }
 
+static void rtl88ee_clear_interrupt(struct ieee80211_hw *hw)
+{
+	struct rtl_priv *rtlpriv = rtl_priv(hw);
+	u32 tmp;
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISR);
+	rtl_write_dword(rtlpriv, REG_HISR, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISRE);
+	rtl_write_dword(rtlpriv, REG_HISRE, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HSISR);
+	rtl_write_dword(rtlpriv, REG_HSISR, tmp);
+}
+
 void rtl88ee_enable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
 	struct rtl_pci *rtlpci = rtl_pcidev(rtl_pcipriv(hw));
 
+	rtl88ee_clear_interrupt(hw);/*clear it here first*/
 	rtl_write_dword(rtlpriv, REG_HIMR,
 			rtlpci->irq_mask[0] & 0xFFFFFFFF);
 	rtl_write_dword(rtlpriv, REG_HIMRE,

--- a/drivers/net/wireless/rtlwifi/rtl8192ee/hw.c
+++ b/drivers/net/wireless/rtlwifi/rtl8192ee/hw.c
@@ -1584,10 +1584,27 @@ void rtl92ee_set_qos(struct ieee80211_hw *hw, int aci)
 	}
 }
 
+static void rtl92ee_clear_interrupt(struct ieee80211_hw *hw)
+{
+	struct rtl_priv *rtlpriv = rtl_priv(hw);
+	u32 tmp;
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISR);
+	rtl_write_dword(rtlpriv, REG_HISR, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISRE);
+	rtl_write_dword(rtlpriv, REG_HISRE, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HSISR);
+	rtl_write_dword(rtlpriv, REG_HSISR, tmp);
+}
+
 void rtl92ee_enable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
 	struct rtl_pci *rtlpci = rtl_pcidev(rtl_pcipriv(hw));
+
+	rtl92ee_clear_interrupt(hw);/*clear it here first*/
 
 	rtl_write_dword(rtlpriv, REG_HIMR, rtlpci->irq_mask[0] & 0xFFFFFFFF);
 	rtl_write_dword(rtlpriv, REG_HIMRE, rtlpci->irq_mask[1] & 0xFFFFFFFF);

--- a/drivers/net/wireless/rtlwifi/rtl8723ae/hw.c
+++ b/drivers/net/wireless/rtlwifi/rtl8723ae/hw.c
@@ -1258,6 +1258,18 @@ void rtl8723e_set_qos(struct ieee80211_hw *hw, int aci)
 	}
 }
 
+static void rtl8723e_clear_interrupt(struct ieee80211_hw *hw)
+{
+	struct rtl_priv *rtlpriv = rtl_priv(hw);
+	u32 tmp;
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISR);
+	rtl_write_dword(rtlpriv, REG_HISR, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISRE);
+	rtl_write_dword(rtlpriv, REG_HISRE, tmp);
+}
+
 void rtl8723e_enable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
@@ -1272,6 +1284,7 @@ void rtl8723e_disable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
 	struct rtl_pci *rtlpci = rtl_pcidev(rtl_pcipriv(hw));
+	rtl8723e_clear_interrupt(hw);/*clear it here first*/
 	rtl_write_dword(rtlpriv, 0x3a8, IMR8190_DISABLED);
 	rtl_write_dword(rtlpriv, 0x3ac, IMR8190_DISABLED);
 	rtlpci->irq_enabled = false;

--- a/drivers/net/wireless/rtlwifi/rtl8723be/hw.c
+++ b/drivers/net/wireless/rtlwifi/rtl8723be/hw.c
@@ -1634,10 +1634,27 @@ void rtl8723be_set_qos(struct ieee80211_hw *hw, int aci)
 	}
 }
 
+static void rtl8723be_clear_interrupt(struct ieee80211_hw *hw)
+{
+	struct rtl_priv *rtlpriv = rtl_priv(hw);
+	u32 tmp;
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISR);
+	rtl_write_dword(rtlpriv, REG_HISR, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISRE);
+	rtl_write_dword(rtlpriv, REG_HISRE, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HSISR);
+	rtl_write_dword(rtlpriv, REG_HSISR, tmp);
+}
+
 void rtl8723be_enable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
 	struct rtl_pci *rtlpci = rtl_pcidev(rtl_pcipriv(hw));
+
+	rtl8723be_clear_interrupt(hw);/*clear it here first*/
 
 	rtl_write_dword(rtlpriv, REG_HIMR, rtlpci->irq_mask[0] & 0xFFFFFFFF);
 	rtl_write_dword(rtlpriv, REG_HIMRE, rtlpci->irq_mask[1] & 0xFFFFFFFF);

--- a/drivers/net/wireless/rtlwifi/rtl8821ae/hw.c
+++ b/drivers/net/wireless/rtlwifi/rtl8821ae/hw.c
@@ -2253,10 +2253,30 @@ void rtl8821ae_set_qos(struct ieee80211_hw *hw, int aci)
 	}
 }
 
+static void rtl8821ae_clear_interrupt(struct ieee80211_hw *hw)
+{
+	struct rtl_priv *rtlpriv = rtl_priv(hw);
+	u32 tmp;
+	tmp = rtl_read_dword(rtlpriv, REG_HISR);
+	/*printk("clear interrupt first:\n");
+	printk("0x%x = 0x%08x\n",REG_HISR, tmp);*/
+	rtl_write_dword(rtlpriv, REG_HISR, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HISRE);
+	/*printk("0x%x = 0x%08x\n",REG_HISRE, tmp);*/
+	rtl_write_dword(rtlpriv, REG_HISRE, tmp);
+
+	tmp = rtl_read_dword(rtlpriv, REG_HSISR);
+	/*printk("0x%x = 0x%08x\n",REG_HSISR, tmp);*/
+	rtl_write_dword(rtlpriv, REG_HSISR, tmp);
+}
+
 void rtl8821ae_enable_interrupt(struct ieee80211_hw *hw)
 {
 	struct rtl_priv *rtlpriv = rtl_priv(hw);
 	struct rtl_pci *rtlpci = rtl_pcidev(rtl_pcipriv(hw));
+
+	rtl8821ae_clear_interrupt(hw);/*clear it here first*/
 
 	rtl_write_dword(rtlpriv, REG_HIMR, rtlpci->irq_mask[0] & 0xFFFFFFFF);
 	rtl_write_dword(rtlpriv, REG_HIMRE, rtlpci->irq_mask[1] & 0xFFFFFFFF);


### PR DESCRIPTION
This reverts commit 1277fa2ab2f9a624a4b0177119ca13b5fd65edd0.

This commit is causing a softlockup during downloads with a RTL8821AE
WiFi card. This is the stack dump:

   CPU: 0 PID: 1108 Comm: wget Not tainted 4.2.0 #28
   Hardware name: ASUSTeK COMPUTER INC. E202SA/E202SA, BIOS 18/2015
   task: e7b92200 ti: f3d28000 task.ti: f3d28000
   EIP: 0060:[<c127ec02>] EFLAGS: 00200202 CPU: 0
    [<c19329be>] tcp_v4_rcv+0x71e/0x8f0
   EIP is at queued_spin_lock_slowpath+0x192/0x1b0
   EAX: 00000101 EBX: 00000101 ECX: f3fe1320 EDX: 00000001
   ESI: 00000101 EDI: 00000001 EBP: f3d29e14 ESP: f3d29e04
    DS: 007b ES: 007b FS: 00d8 GS: 0033 SS: 0068
   CR0: 8005003b CR2: a9f78000 CR3: 2eb52000 CR4: 001006d0
   Stack:
    00000101 00000001 f3d29ed0
    [<c195f08a>] ? iptable_filter_hook+0x2a/0x80
    [<c190ff3c>] ip_local_deliver_finish+0x6c/0x1f0
    [<c1910271>] ip_local_deliver+0x91/0xa0
    [<c190fed0>] ? ip_rcv_finish+0x320/0x320
    [<c190fc11>] ip_rcv_finish+0x61/0x320
    [<c19105b5>] ip_rcv+0x335/0x420
    [<c19b9302>] ? packet_rcv+0x32/0x340
    [<c190fbb0>] ? inet_del_offload+0x30/0x30
    [<c18cd1fa>] __netif_receive_skb_core+0x5ca/0x960
    [<c18cd5a6>] __netif_receive_skb+0x16/0x60
    [<c18cd612>] netif_receive_skb_internal+0x22/0x80
    [<c18cd687>] netif_receive_skb_sk+0x17/0x50
    [<c1a6bc8a>] ieee80211_deliver_skb+0x10a/0x1a0
    [<c1a6d655>] ieee80211_rx_handlers+0x1025/0x1da0
    [<c1337552>] ? kfree+0x112/0x120
    [<c1a6e546>] ieee80211_prepare_and_rx_handle+0x176/0x9a0
    [<c13373af>] ? kmem_cache_free+0xbf/0x120
    [<c1a6f2c7>] ieee80211_rx+0x557/0x860
    [<c1a4bd47>] ieee80211_tasklet_handler+0xa7/0xb0
    [<c124c6a9>] tasklet_action+0xb9/0xc0
    [<c124c94c>] __do_softirq+0x7c/0x220
    [<c124c8d0>] ? cpu_callback+0x160/0x160
    [<c120430d>] do_softirq_own_stack+0x1d/0x30
    <IRQ>
    [<c124cc15>] irq_exit+0x85/0x90
    [<c1203c50>] do_IRQ+0x40/0xb0
    [<c1aaca6c>] common_interrupt+0x2c/0x34
    [<c181c7cb>] ? cpuidle_enter_state+0xbb/0x2a0
    [<c181c9cf>] cpuidle_enter+0xf/0x20
    [<c127d02e>] call_cpuidle+0x2e/0x60
    [<c127d1ea>] cpu_startup_entry+0x18a/0x290
    [<c1231e5f>] start_secondary+0x10f/0x130

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#5687]