### PR TITLE
Packaging: remove control markup for stage1

### DIFF
--- a/debian.master/control.stub.in
+++ b/debian.master/control.stub.in
@@ -8,45 +8,44 @@ Build-Depends:
  dh-systemd,
  cpio,
  kernel-wedge (>= 2.24ubuntu1),
- kmod <!stage1>,
- makedumpfile [amd64 i386] <!stage1>,
- libelf-dev <!stage1>,
- libnewt-dev <!stage1>,
- libiberty-dev <!stage1>,
- rsync <!stage1>,
- libdw-dev <!stage1>,
- libpci-dev <!stage1>,
- dpkg (>= 1.16.0~ubuntu4) <!stage1>,
- pkg-config <!stage1>,
- flex <!stage1>,
- bison <!stage1>,
- libunwind8-dev [amd64 arm64 armhf i386 powerpc ppc64el] <!stage1>,
- openssl <!stage1>,
- libssl-dev <!stage1>,
- libaudit-dev <!stage1>,
- bc <!stage1>,
- python-dev <!stage1>,
- gawk <!stage1>,
- device-tree-compiler [powerpc] <!stage1>,
- u-boot-tools [powerpc] <!stage1>,
- libc6-dev-ppc64 [powerpc] <!stage1>,
- libudev-dev <!stage1>,
- autoconf <!stage1>,
- automake <!stage1>,
- libtool <!stage1>,
- uuid-dev <!stage1>,
+ kmod,
+ makedumpfile [amd64 i386],
+ libelf-dev,
+ libnewt-dev,
+ libiberty-dev,
+ rsync,
+ libdw-dev,
+ libpci-dev,
+ dpkg (>= 1.16.0~ubuntu4),
+ pkg-config,
+ flex,
+ bison,
+ libunwind8-dev [amd64 arm64 armhf i386 powerpc ppc64el],
+ openssl,
+ libssl-dev,
+ libaudit-dev,
+ bc,
+ python-dev,
+ gawk,
+ device-tree-compiler [powerpc],
+ u-boot-tools [powerpc],
+ libc6-dev-ppc64 [powerpc],
+ libudev-dev,
+ autoconf,
+ automake,
+ libtool,
+ uuid-dev,
 Build-Depends-Indep:
- xmlto <!stage1>,
- transfig <!stage1>,
- bzip2 <!stage1>,
- sharutils <!stage1>,
- asciidoc <!stage1>,
+ xmlto,
+ transfig,
+ bzip2,
+ sharutils,
+ asciidoc,
 Vcs-Git: git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/wily
 XS-Testsuite: autopkgtest
 #XS-Testsuite-Depends: gcc-4.7 binutils
 
 Package: SRCPKGNAME-source-PKGVER
-Build-Profiles: <!stage1>
 Architecture: all
 Section: devel
 Priority: optional
@@ -70,7 +69,6 @@ Description: Linux kernel source for version PKGVER with Ubuntu patches
  package instead.
 
 Package: SRCPKGNAME-doc
-Build-Profiles: <!stage1>
 Architecture: all
 Section: doc
 Priority: optional
@@ -85,7 +83,6 @@ Description: Linux kernel specific documentation for version PKGVER
  contained in each file.
 
 Package: SRCPKGNAME-headers-PKGVER-ABINUM
-Build-Profiles: <!stage1>
 Architecture: all
 Multi-Arch: foreign
 Section: devel
@@ -110,7 +107,6 @@ Description: Linux Kernel Headers for development
  your kernel. Use SRCPKGNAME-headers-* packages for that.
 
 Package: SRCPKGNAME-tools-common
-Build-Profiles: <!stage1>
 Architecture: all
 Multi-Arch: foreign
 Section: kernel
@@ -123,7 +119,6 @@ Description: Linux kernel version specific tools for version PKGVER
  version PGKVER.
 
 Package: SRCPKGNAME-tools-PKGVER-ABINUM
-Build-Profiles: <!stage1>
 Architecture: i386 amd64 armhf arm64 powerpc ppc64el s390x
 Section: devel
 Priority: optional
@@ -136,7 +131,6 @@ Description: Linux kernel version specific tools for version PKGVER-ABINUM
  You probabaly want to install linux-tools-PKGVER-ABINUM-<flavour>.
 
 Package: SRCPKGNAME-cloud-tools-common
-Build-Profiles: <!stage1>
 Architecture: all
 Multi-Arch: foreign
 Section: kernel
@@ -149,7 +143,6 @@ Description: Linux kernel version specific cloud tools for version PKGVER
  version locked tools for cloud tools for version PGKVER.
 
 Package: SRCPKGNAME-cloud-tools-PKGVER-ABINUM
-Build-Profiles: <!stage1>
 Architecture: i386 amd64 armhf
 Section: devel
 Priority: optional


### PR DESCRIPTION
Our build infrastructure (Jenkins) do not support BuildProfileSpec or
stage markup yet.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

[endlessm/eos-shell#6228]