### PR TITLE
T10942: ideapad_laptop: Makes radio ON/OFF key emit KEY_RFKILL

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -564,7 +564,7 @@ static const struct key_entry ideapad_keymap[] = {
 	{ KE_KEY, 6,  { KEY_SWITCHVIDEOMODE } },
 	{ KE_KEY, 7,  { KEY_CAMERA } },
 	{ KE_KEY, 11, { KEY_F16 } },
-	{ KE_KEY, 13, { KEY_WLAN } },
+	{ KE_KEY, 13, { KEY_RFKILL } },
 	{ KE_KEY, 16, { KEY_PROG1 } },
 	{ KE_KEY, 17, { KEY_PROG2 } },
 	{ KE_KEY, 64, { KEY_PROG3 } },


### PR DESCRIPTION
Pressing a key to turn radios off should emit KEY_RFKILL instead of
KEY_WLAN.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T10942