### PR TITLE
T11116: config: Disable nouveau on the Asus N552VW

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1061,6 +1061,17 @@ err_free:
 	return ERR_PTR(err);
 }
 
+static const struct dmi_system_id nouveau_modeset_0[] = {
+	{
+		.ident = "ASUSTeK COMPUTER INC. N552VW", /* Lenovo Yoga 900 */
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "N552VW"),
+		},
+	},
+	{ }
+};
+
 static int __init
 nouveau_drm_init(void)
 {
@@ -1068,6 +1079,9 @@ nouveau_drm_init(void)
 	driver_pci.set_busid = drm_pci_set_busid;
 	driver_platform = driver_stub;
 	driver_platform.set_busid = drm_platform_set_busid;
+
+	if (dmi_check_system(nouveau_modeset_0))
+		nouveau_modeset = 0;
 
 	nouveau_display_options();
 


### PR DESCRIPTION
The Asus N552VW has two video cards (Intel+NVIDIA), we only really use
the Intel one, but the NVIDIA keeps running, raising the machine's
temperature, triggering the fan at full speed, wasting energy, and
sending a lot of errors to the kernel log.

Disable it for now, and revisit later for a proper fix, as some future
machines might depend on it.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T11116