### PR TITLE
asus-nb-wmi: Fix product name typo on DMI quirk

### DIFF
--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -330,10 +330,10 @@ static const struct dmi_system_id asus_quirks[] = {
 	},
 	{
 		.callback = dmi_matched,
-		.ident = "ASUSTeK COMPUTER INC. X552VW",
+		.ident = "ASUSTeK COMPUTER INC. N552VW",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "X552VW"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "N552VW"),
 		},
 		.driver_data = &quirk_no_rfkill,
 	},


### PR DESCRIPTION
Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>