### PR TITLE
T10839: Fix build

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -436,10 +436,6 @@ static const struct pci_device_id pciidlist[] = {
 	INTEL_SKL_GT3_IDS(&intel_skylake_gt3_info),
 	INTEL_SKL_GT4_IDS(&intel_skylake_gt3_info),
 	INTEL_BXT_IDS(&intel_broxton_info),
-	INTEL_KBL_GT1_IDS(&intel_kabylake_info),
-	INTEL_KBL_GT2_IDS(&intel_kabylake_info),
-	INTEL_KBL_GT3_IDS(&intel_kabylake_gt3_info),
-	INTEL_KBL_GT4_IDS(&intel_kabylake_gt3_info),
 	{0, 0, 0}
 };
 


### PR DESCRIPTION
NOTE FOR FUTURE REBASE: squash this commit on the one introducing the
problem, so we don't have a broken build in our history (which makes
bisects harder).

This fixes a problem introduced by
9c3df35 Revert "UBUNTU: SAUCE: i915_bpo: Support only SKL, KBL and BXT with the backport driver"
which breaks our build with

In file included from /usr/src/packages/BUILD/linux-4.4.0/include/drm/i915_drm.h:29:0,
                 from /usr/src/packages/BUILD/linux-4.4.0/drivers/gpu/drm/i915/i915_drv.c:33:
/usr/src/packages/BUILD/linux-4.4.0/drivers/gpu/drm/i915/i915_drv.c:439:21: error: 'intel_kabylake_info' undeclared here (not in a function)
  INTEL_KBL_GT1_IDS(&intel_kabylake_info),
                     ^
/usr/src/packages/BUILD/linux-4.4.0/include/drm/i915_pciids.h:42:18: note: in definition of macro 'INTEL_VGA_DEVICE'
  (unsigned long) info }
                  ^
/usr/src/packages/BUILD/linux-4.4.0/drivers/gpu/drm/i915/i915_drv.c:439:2: note: in expansion of macro 'INTEL_KBL_GT1_IDS'
  INTEL_KBL_GT1_IDS(&intel_kabylake_info),
  ^
/usr/src/packages/BUILD/linux-4.4.0/drivers/gpu/drm/i915/i915_drv.c:441:21: error: 'intel_kabylake_gt3_info' undeclared here (not in a function)
  INTEL_KBL_GT3_IDS(&intel_kabylake_gt3_info),
                     ^
/usr/src/packages/BUILD/linux-4.4.0/include/drm/i915_pciids.h:42:18: note: in definition of macro 'INTEL_VGA_DEVICE'
  (unsigned long) info }
                  ^
/usr/src/packages/BUILD/linux-4.4.0/drivers/gpu/drm/i915/i915_drv.c:441:2: note: in expansion of macro 'INTEL_KBL_GT3_IDS'
  INTEL_KBL_GT3_IDS(&intel_kabylake_gt3_info),
  ^
make[6]: *** [drivers/gpu/drm/i915/i915_drv.o] Error 1
make[5]: *** [drivers/gpu/drm/i915] Error 2
make[4]: *** [drivers/gpu/drm] Error 2
make[3]: *** [drivers/gpu] Error 2
make[3]: *** Waiting for unfinished jobs....

Since KBL is not yet supported by the i915 driver we're shipping in tree.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T10839