### PR TITLE
T12101: Restrict more kernel functionality when secure booted

### DIFF
--- a/arch/x86/boot/compressed/eboot.c
+++ b/arch/x86/boot/compressed/eboot.c
@@ -848,6 +848,22 @@ out:
 	return status;
 }
 
+#define MEMORY_ONLY_RESET_CONTROL_GUID \
+	EFI_GUID (0xe20939be, 0x32d4, 0x41be, 0xa1, 0x50, 0x89, 0x7f, 0x85, 0xd4, 0x98, 0x29)
+
+static void enable_reset_attack_mitigation(void)
+{
+	u8 val = 1;
+	efi_guid_t var_guid = MEMORY_ONLY_RESET_CONTROL_GUID;
+
+	/* Ignore the return value here - there's not really a lot we can do */
+	efi_early->call((unsigned long)sys_table->runtime->set_variable,
+			L"MemoryOverwriteRequestControl", &var_guid,
+			EFI_VARIABLE_NON_VOLATILE |
+			EFI_VARIABLE_BOOTSERVICE_ACCESS |
+			EFI_VARIABLE_RUNTIME_ACCESS, sizeof(val), val);
+}
+
 static int get_secure_boot(void)
 {
 	u8 sb, setup, moksbstate;
@@ -1482,6 +1498,12 @@ struct boot_params *efi_main(struct efi_config *c,
 		setup_boot_services64(efi_early);
 	else
 		setup_boot_services32(efi_early);
+
+	/*
+	 * Ask the firmware to clear memory if we don't have a clean
+	 * shutdown
+	 */
+	enable_reset_attack_mitigation();
 
 	sanitize_boot_params(boot_params);
 

--- a/arch/x86/kernel/kexec-bzimage64.c
+++ b/arch/x86/kernel/kexec-bzimage64.c
@@ -180,6 +180,7 @@ setup_efi_state(struct boot_params *params, unsigned long params_load_addr,
 	if (efi_enabled(EFI_OLD_MEMMAP))
 		return 0;
 
+	params->secure_boot = boot_params.secure_boot;
 	ei->efi_loader_signature = current_ei->efi_loader_signature;
 	ei->efi_systab = current_ei->efi_systab;
 	ei->efi_systab_hi = current_ei->efi_systab_hi;

--- a/drivers/acpi/apei/einj.c
+++ b/drivers/acpi/apei/einj.c
@@ -521,6 +521,9 @@ static int einj_error_inject(u32 type, u32 flags, u64 param1, u64 param2,
 	int rc;
 	unsigned long pfn;
 
+	if (secure_modules())
+		return -EPERM;
+
 	/* If user manually set "flags", make sure it is legal */
 	if (flags && (flags &
 		~(SETWA_FLAGS_APICID|SETWA_FLAGS_MEM|SETWA_FLAGS_PCIE_SBDF)))

--- a/drivers/acpi/osl.c
+++ b/drivers/acpi/osl.c
@@ -669,6 +669,12 @@ void __init acpi_initrd_override(void *data, size_t size)
 	if (table_nr == 0)
 		return;
 
+	if (secure_modules()) {
+		pr_notice(PREFIX
+			"module signing is enforced, ignoring table override\n");
+		return;
+	}
+
 	acpi_tables_addr =
 		memblock_find_in_range(0, max_low_pfn_mapped << PAGE_SHIFT,
 				       all_tables_size, PAGE_SIZE);

--- a/drivers/char/mem.c
+++ b/drivers/char/mem.c
@@ -566,6 +566,9 @@ static ssize_t read_port(struct file *file, char __user *buf,
 	unsigned long i = *ppos;
 	char __user *tmp = buf;
 
+	if (secure_modules())
+		return -EPERM;
+
 	if (!access_ok(VERIFY_WRITE, buf, count))
 		return -EFAULT;
 	while (count-- > 0 && i < 65536) {

--- a/kernel/power/user.c
+++ b/kernel/power/user.c
@@ -52,6 +52,9 @@ static int snapshot_open(struct inode *inode, struct file *filp)
 	if (!hibernation_available())
 		return -EPERM;
 
+	if (secure_modules())
+		return -EPERM;
+
 	lock_system_sleep();
 
 	if (!atomic_add_unless(&snapshot_device_available, -1, 0)) {


### PR DESCRIPTION
Backport Matthew Garrett's securelevel framework to prevent malicious users or hardware / firmware to disable secure boot and potentially chainload another OS or bootloader.

https://phabricator.endlessm.com/T12101