### PR TITLE
fixup! uswsusp: Disable when module signing is enforced

### DIFF
--- a/kernel/power/user.c
+++ b/kernel/power/user.c
@@ -24,6 +24,7 @@
 #include <linux/console.h>
 #include <linux/cpu.h>
 #include <linux/freezer.h>
+#include <linux/module.h>
 
 #include <asm/uaccess.h>
 


### PR DESCRIPTION
Fix missing include.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T12101