### PR TITLE
PCI: disable MSI on problematic ASUS X541UV

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2296,6 +2296,14 @@ static const struct dmi_system_id broken_msi_table[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "X555UB"),
 		},
 	},
+	{
+		/* Asus laptop with PCIe AER spam when MSI is enabled. */
+		.ident = "ASUSTeK COMPUTER INC. X541UV",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X541UV"),
+		},
+	},
 	{}
 };
 static void quirk_disable_all_msi2(struct pci_dev *dev)

--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2290,14 +2290,6 @@ static const struct dmi_system_id broken_msi_table[] = {
 	},
 	{
 		/* Asus laptop with PCIe AER spam when MSI is enabled. */
-		.ident = "ASUSTeK COMPUTER INC. X456UR",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "X541UV"),
-		},
-	},
-	{
-		/* Asus laptop with PCIe AER spam when MSI is enabled. */
 		.ident = "ASUSTeK COMPUTER INC. X555UB",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),


### PR DESCRIPTION
 pcieport 0000:00:1c.5: AER: Corrected error received: id=00e5
 pcieport 0000:00:1c.5: PCIe Bus Error: severity=Corrected,
type=Physical Layer, id=00e5(Receiver ID)
 pcieport 0000:00:1c.5:   device [8086:9d15] error status/mask=00000001/00002000
 pcieport 0000:00:1c.5:    [ 0] Receiver Error         (First)

avoid this with adding a quirk for X541UV