### PR TITLE
config: Build linux-source with contents

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -41,7 +41,6 @@ do_tools_common=true
 skipabi=true
 skipmodule=true
 do_cloud_tools=false
-do_source_package=false
 do_doc_package=false
 
 # Don't build tools or udebs in a cross compile environment.

--- a/debian/rules.d/0-common-vars.mk
+++ b/debian/rules.d/0-common-vars.mk
@@ -141,15 +141,9 @@ do_doc_package_content=false
 endif
 doc_pkg_name=$(src_pkg_name)-doc
 
-#
-# Similarly with the linux-source package, you need not build it as a developer. Its
-# somewhat I/O intensive and utterly useless.
-#
+# linux-source is used to build cross-compilers, default to building it.
 do_source_package=true
 do_source_package_content=true
-ifeq ($(full_build),false)
-do_source_package_content=false
-endif
 
 # linux-libc-dev may not be needed, default to building it.
 do_libc_dev_package=true


### PR DESCRIPTION
This is used by cross-toolchain-base, which is needed to build
cross-compilers.

https://phabricator.endlessm.com/T10613