### PR TITLE
vbox: Fix kernel panic after installing guest additions

### DIFF
--- a/ubuntu/vbox/vboxvideo/vbox_ttm.c
+++ b/ubuntu/vbox/vboxvideo/vbox_ttm.c
@@ -274,6 +274,8 @@ struct ttm_bo_driver vbox_bo_driver = {
     .verify_access = vbox_bo_verify_access,
     .io_mem_reserve = &vbox_ttm_io_mem_reserve,
     .io_mem_free = &vbox_ttm_io_mem_free,
+    .lru_tail = &ttm_bo_default_lru_tail,
+    .swap_lru_tail = &ttm_bo_default_swap_lru_tail,
 };
 
 int vbox_mm_init(struct vbox_private *vbox)


### PR DESCRIPTION
This applies the fix pointed in
https://www.virtualbox.org/ticket/15769#comment:4

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>