### PR TITLE
Bluetooth: Add Realtek support for Foxconn MT13

### DIFF
--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -19,6 +19,7 @@
 #include <linux/firmware.h>
 #include <asm/unaligned.h>
 #include <linux/usb.h>
+#include <linux/dmi.h>
 
 #include <net/bluetooth/bluetooth.h>
 #include <net/bluetooth/hci_core.h>
@@ -33,6 +34,11 @@
 #define RTL_ROM_LMP_8723B	0x8723
 #define RTL_ROM_LMP_8821A	0x8821
 #define RTL_ROM_LMP_8761A	0x8761
+
+/* Antenna selection bytes: Realtek*/
+const uint8_t RTK_CONFIG_SIGNATURE[6] = {0x55, 0xab, 0x23, 0x87, 0x04, 0x00};
+const uint8_t CONFIG_S0_ANTTENA[4] = {0xE3, 0x01, 0x01, 0x04};
+const uint8_t CONFIG_S1_ANTTENA[4] = {0xE3, 0x01, 0x01, 0x00};
 
 static int rtl_read_rom_version(struct hci_dev *hdev, u8 *version)
 {
@@ -62,6 +68,20 @@ static int rtl_read_rom_version(struct hci_dev *hdev, u8 *version)
 	kfree_skb(skb);
 	return 0;
 }
+
+/*
+ * Workaround for Bluetooth on Foxconn InFocus MT13
+ */
+static const struct dmi_system_id bt_force_S0_antenna[] = {
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Foxconn"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Braswell"),
+			DMI_MATCH(DMI_BOARD_NAME, "0E68"),		
+		},
+	},
+	{}
+};
 
 static int rtl8723b_parse_firmware(struct hci_dev *hdev, u16 lmp_subver,
 				   const struct firmware *fw,
@@ -200,6 +220,18 @@ static int rtl8723b_parse_firmware(struct hci_dev *hdev, u16 lmp_subver,
 		return -ENOMEM;
 
 	memcpy(buf + patch_length - 4, &epatch_info->fw_version, 4);
+	
+	/* Workaround for Foxconn MT13. 
+	 * The default BT antenna port for this laptop is not populated,
+	 * so we force Antenna S0.
+	 */
+	if (dmi_check_system(bt_force_S0_antenna)) {
+		BT_DBG("Using S0 antenna");
+		buf = krealloc(buf, patch_length + 10, GFP_KERNEL);
+		memcpy(buf + patch_length, RTK_CONFIG_SIGNATURE, 6);
+		memcpy(buf + patch_length + 6, CONFIG_S0_ANTTENA, 4);
+		len += 10;
+	}
 
 	*_buf = buf;
 	return len;

--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -334,6 +334,7 @@ static const struct usb_device_id blacklist_table[] = {
 	{ USB_DEVICE(0x13d3, 0x3410), .driver_info = BTUSB_REALTEK },
 	{ USB_DEVICE(0x13d3, 0x3416), .driver_info = BTUSB_REALTEK },
 	{ USB_DEVICE(0x13d3, 0x3459), .driver_info = BTUSB_REALTEK },
+	{ USB_DEVICE(0x0489, 0xe09e), .driver_info = BTUSB_REALTEK },
 
 	/* Additional Realtek 8821AE Bluetooth devices */
 	{ USB_DEVICE(0x0b05, 0x17dc), .driver_info = BTUSB_REALTEK },


### PR DESCRIPTION
Realtek ships certain bluetooth USB devices which report themselves as
standard USB bluetooth devices, but which require special drivers.

Here we add support for the Realtek 8723BE devices shipped in the
Foxconn MT13.

https://phabricator.endlessm.com/T12741

Signed-off-by: Benjamin Antin ben.antin@endlessm.com