### PR TITLE
sound/hda: ALC256 mic and headset-mode fixups for Asus laptops

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -6079,6 +6079,10 @@ static const struct snd_hda_pin_quirk alc269_pin_fixup_tbl[] = {
 	SND_HDA_PIN_QUIRK(0x10ec0298, 0x1028, "Dell", ALC298_FIXUP_DELL1_MIC_NO_PRESENCE,
 		ALC298_STANDARD_PINS,
 		{0x17, 0x90170150}),
+	SND_HDA_PIN_QUIRK(0x10ec0256, 0x1043, "ASUS", ALC256_FIXUP_ASUS_MIC,
+		{0x14, 0x90170110},
+		{0x1b, 0x90a70130},
+		{0x21, 0x04211020}),
 	{}
 };
 


### PR DESCRIPTION
This fixes headphone jack sensing and enables use of the internal
microphone. It's verified on Asus E402NA.

Signed-off-by: Chris Chiu <chiu@endlessm.com>

https://phabricator.endlessm.com/T13185