### PR TITLE
Input: i8042 - don't run self test on Asus Z450LA

### DIFF
--- a/drivers/input/serio/i8042.c
+++ b/drivers/input/serio/i8042.c
@@ -1558,9 +1558,17 @@ static int i8042_remove(struct platform_device *dev)
 
 static const struct dmi_system_id i8042_dmi_noselftest_table[] __initconst = {
 	{
+		.ident = "ASUS X455LAB",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
 			DMI_MATCH(DMI_PRODUCT_NAME, "X455LAB"),
+		},
+	},
+	{
+		.ident = "ASUS Z450LA",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Z450LA"),
 		},
 	},
 	{}


### PR DESCRIPTION
The self-test command causes the trackpad on this model to stop
reporting. Add DMI quirk for the Z540LA so we don't send the self test
command.

Signed-off-by: Benjamin Antin <ben.antin@endlessm.com>

https://phabricator.endlessm.com/T13468