### PR TITLE
debian: Allow installation of signed linux-image packages

### DIFF
--- a/debian.master/control.d/flavour-control.stub
+++ b/debian.master/control.d/flavour-control.stub
@@ -30,6 +30,8 @@ Provides: linux-image, fuse-module, =PROVIDES=${linux:rprovides}
 Depends: ${misc:Depends}, ${shlibs:Depends}, initramfs-tools | linux-initramfs-tool, kmod
 Recommends: BOOTLOADER
 Suggests: fdutils, SRCPKGNAME-doc-PKGVER | SRCPKGNAME-source-PKGVER, SRCPKGNAME-tools, linux-headers-PKGVER-ABINUM-FLAVOUR
+Conflicts: linux-signed-image-PKGVER-ABINUM-FLAVOUR
+Replaces: linux-signed-image-PKGVER-ABINUM-FLAVOUR
 Description: Linux kernel image for version PKGVER on DESC
  This package contains the Linux kernel image for version PKGVER on
  DESC.
@@ -51,7 +53,7 @@ Build-Profiles: <!stage1>
 Architecture: ARCH
 Section: kernel
 Priority: optional
-Depends: ${misc:Depends}, ${shlibs:Depends}, linux-image-PKGVER-ABINUM-FLAVOUR, crda | wireless-crda
+Depends: ${misc:Depends}, ${shlibs:Depends}, linux-signed-image-PKGVER-ABINUM-FLAVOUR [amd64] | linux-image-PKGVER-ABINUM-FLAVOUR, crda | wireless-crda
 Description: Linux kernel extra modules for version PKGVER on DESC
  This package contains the Linux kernel extra modules for version PKGVER on
  DESC.


### PR DESCRIPTION
We intend to created linux-signed-image packages with kernels signed for
UEFI. These packages are identical to the unsigned linux-images but with
the vmlinuz file signed. In order to let these new packages install
correctly, they need to conflict with the normal unsigned packages.
Likewise, the linux-image-extra modules packages need to allow them as
an alternate dependency.

https://phabricator.endlessm.com/T12944