### PR TITLE
mfd: intel-lpss: Pass I2C SDA hold time to controller driver on APL

### DIFF
--- a/drivers/mfd/intel-lpss-pci.c
+++ b/drivers/mfd/intel-lpss-pci.c
@@ -100,14 +100,14 @@ static const struct intel_lpss_platform_info bxt_uart_info = {
 };
 
 static struct property_entry bxt_i2c_properties[] = {
-	PROPERTY_ENTRY_U32("i2c-sda-hold-time-ns", 42),
+	PROPERTY_ENTRY_U32("i2c-sda-hold-time-ns", 230),
 	PROPERTY_ENTRY_U32("i2c-sda-falling-time-ns", 171),
 	PROPERTY_ENTRY_U32("i2c-scl-falling-time-ns", 208),
 	{ },
 };
 
 static const struct intel_lpss_platform_info bxt_i2c_info = {
-	.clk_rate = 133000000,
+	.clk_rate = 120000000,
 	.properties = bxt_i2c_properties,
 };
 


### PR DESCRIPTION
The I2C arbitration lost erros happens on ASUS Apollolake models
(on E402NA and E403NA) with ELAN touchpad and it requires programming
non-zero SDA hold time. Tried the Skylake I2C SDA hold time and clock
rate which fixed similar issue on Lenovo Yoga 900. It works fine w/o
problem.

Error messages are as following.
i2c_designware i2c_designware.1: i2c_dw_handle_tx_abort: lost arbitration
hid (null): reading report descriptor failed
i2c_hid i2c-ELAN1200:00 can't add hid device: -5
i2c_hid: probe of i2c-ELAN1200:00 failed with error -5

Signed-off-by: Chris Chiu <chiu@endlessm.com>

https://phabricator.endlessm.com/T13616