### PR TITLE
fixup! mfd: intel-lpss: Add default I2C device properties for Lake

### DIFF
--- a/drivers/mfd/intel-lpss-acpi.c
+++ b/drivers/mfd/intel-lpss-acpi.c
@@ -67,9 +67,13 @@ static struct property_entry apl_i2c_properties[] = {
 	{ },
 };
 
+static struct property_set apl_i2c_pset = {
+	.properties = apl_i2c_properties,
+};
+
 static const struct intel_lpss_platform_info apl_i2c_info = {
 	.clk_rate = 133000000,
-	.properties = apl_i2c_properties,
+	.pset = &apl_i2c_pset,
 };
 
 static const struct acpi_device_id intel_lpss_acpi_ids[] = {

--- a/drivers/mfd/intel-lpss-pci.c
+++ b/drivers/mfd/intel-lpss-pci.c
@@ -130,9 +130,13 @@ static struct property_entry apl_i2c_properties[] = {
 	{ },
 };
 
+static struct property_set apl_i2c_pset = {
+	.properties = apl_i2c_properties,
+};
+
 static const struct intel_lpss_platform_info apl_i2c_info = {
 	.clk_rate = 133000000,
-	.properties = apl_i2c_properties,
+	.pset = &apl_i2c_pset,
 };
 
 static const struct intel_lpss_platform_info kbl_info = {


### PR DESCRIPTION
This fixes a build error, and should be squashed on the commit that
creates the problem on a future rebase.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>