### PR TITLE
tmpfs: add user_xattr mount option

### DIFF
--- a/include/linux/shmem_fs.h
+++ b/include/linux/shmem_fs.h
@@ -35,6 +35,7 @@ struct shmem_sb_info {
 	kgid_t gid;		    /* Mount gid for root directory */
 	umode_t mode;		    /* Mount mode for root directory */
 	struct mempolicy *mpol;     /* default memory policy for mappings */
+	bool user_xattr;	    /* allow xattrs in user. namespace? */
 };
 
 static inline struct shmem_inode_info *SHMEM_I(struct inode *inode)


### PR DESCRIPTION
For the reasons discussed at
<http://www.spinics.net/lists/linux-mm/msg109982.html>, this simplistic
implementation of user xattrs can't simply be made available to
everyone.

We want user xattrs on tmpfs to support flatpak running as an
unprivileged user on overlayfs whose upper fs is tmpfs, a situation
which only arises in our pristine image boots. So, for our purposes, a
mount flag is okay: we can set it at the same time as setting up the
overlays.

https://phabricator.endlessm.com/T13817

Signed-off-by: Will Thompson <wjt@endlessm.com>