### PR TITLE
tmpfs: add user_xattr mount option

### DIFF
--- a/include/linux/shmem_fs.h
+++ b/include/linux/shmem_fs.h
@@ -40,6 +40,7 @@ struct shmem_sb_info {
 	spinlock_t shrinklist_lock;   /* Protects shrinklist */
 	struct list_head shrinklist;  /* List of shinkable inodes */
 	unsigned long shrinklist_len; /* Length of shrinklist */
+	bool user_xattr;	      /* allow xattrs in user. namespace? */
 };
 
 static inline struct shmem_inode_info *SHMEM_I(struct inode *inode)

--- a/mm/shmem.c
+++ b/mm/shmem.c
@@ -3283,6 +3283,40 @@ static int shmem_xattr_handler_set(const struct xattr_handler *handler,
 	return simple_xattr_set(&info->xattrs, name, value, size, flags);
 }
 
+static int shmem_user_xattr_handler_get(const struct xattr_handler *handler,
+					struct dentry *dentry, struct inode *inode,
+					const char *name, void *buffer, size_t size)
+{
+	struct shmem_sb_info *sbinfo = SHMEM_SB(inode->i_sb);
+
+	if (!sbinfo->user_xattr) {
+		return -EOPNOTSUPP;
+	}
+
+	return shmem_xattr_handler_get(handler, dentry, inode, name, buffer, size);
+}
+
+static int shmem_user_xattr_handler_set(const struct xattr_handler *handler,
+					struct dentry *dentry, struct inode *inode,
+					const char *name, const void *value,
+					size_t size, int flags)
+{
+	struct shmem_sb_info *sbinfo = SHMEM_SB(inode->i_sb);
+
+	if (!sbinfo->user_xattr) {
+		return -EOPNOTSUPP;
+	}
+
+	return shmem_xattr_handler_set(handler, dentry, inode, name, value,
+			size, flags);
+}
+
+static const struct xattr_handler shmem_user_xattr_handler = {
+	.prefix = XATTR_USER_PREFIX,
+	.get = shmem_user_xattr_handler_get,
+	.set = shmem_user_xattr_handler_set,
+};
+
 static const struct xattr_handler shmem_security_xattr_handler = {
 	.prefix = XATTR_SECURITY_PREFIX,
 	.get = shmem_xattr_handler_get,
@@ -3300,6 +3334,7 @@ static const struct xattr_handler *shmem_xattr_handlers[] = {
 	&posix_acl_access_xattr_handler,
 	&posix_acl_default_xattr_handler,
 #endif
+	&shmem_user_xattr_handler,
 	&shmem_security_xattr_handler,
 	&shmem_trusted_xattr_handler,
 	NULL
@@ -3416,6 +3451,11 @@ static int shmem_parse_options(char *options, struct shmem_sb_info *sbinfo,
 			continue;
 		if ((value = strchr(this_char,'=')) != NULL) {
 			*value++ = 0;
+		} else if (!strcmp(this_char,"user_xattr")) {
+			sbinfo->user_xattr = true;
+			if (value != NULL)
+				goto bad_val;
+			continue;
 		} else {
 			pr_err("tmpfs: No value for mount option '%s'\n",
 			       this_char);
@@ -3534,6 +3574,7 @@ static int shmem_remount_fs(struct super_block *sb, int *flags, char *data)
 	sbinfo->max_blocks  = config.max_blocks;
 	sbinfo->max_inodes  = config.max_inodes;
 	sbinfo->free_inodes = config.max_inodes - inodes;
+	sbinfo->user_xattr  = config.user_xattr;
 
 	/*
 	 * Preserve previous mempolicy unless mpol remount option was specified.


### PR DESCRIPTION
For the reasons discussed at
<http://www.spinics.net/lists/linux-mm/msg109982.html>, this simplistic
implementation of user xattrs can't simply be made available to
everyone.

We want user xattrs on tmpfs to support flatpak running as an
unprivileged user on overlayfs whose upper fs is tmpfs, a situation
which only arises in our pristine image boots. So, for our purposes, a
mount flag is okay: we can set it at the same time as setting up the
overlays.

This is a forward-port of #179.

https://phabricator.endlessm.com/T13817