### PR TITLE
asus-wmi: Add quirk_no_rfkill for the Asus UX360CAK/UX360UA

### DIFF
--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -351,6 +351,24 @@ static const struct dmi_system_id asus_quirks[] = {
 		},
 		.driver_data = &quirk_no_rfkill,
 	},
+	{
+		.callback = dmi_matched,
+		.ident = "ASUSTeK COMPUTER INC. UX360CAK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "UX360CAK"),
+		},
+		.driver_data = &quirk_no_rfkill,
+	},
+	{
+		.callback = dmi_matched,
+		.ident = "ASUSTeK COMPUTER INC. UX360UA",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "UX360UA"),
+		},
+		.driver_data = &quirk_no_rfkill,
+	},
 	{},
 };
 


### PR DESCRIPTION
The Asus UX360CAK/UX360UA has airplane-mode indicator LED and the WMI
WLAN user bit set, so asus-wmi uses ASUS_WMI_DEVID_WLAN_LED (0x00010002)
to store the wlan state, which has a side-effect of driving the airplane
mode indicator LED in an inverted fashion. quirk_no_rfkill prevents
asus-wmi from registering RFKill switches at all for this laptop and
allows asus-wireless to drive the LED through the ASHS ACPI device.

https://phabricator.endlessm.com/T13916

Signed-off-by: Chris Chiu chiu@endlessm.com
