### PR TITLE
Input: soc_button_array - use ACPI0011 specified gpio for "Volume Up/…

### DIFF
--- a/drivers/input/misc/soc_button_array.c
+++ b/drivers/input/misc/soc_button_array.c
@@ -18,6 +18,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/gpio_keys.h>
 #include <linux/platform_device.h>
+#include <linux/dmi.h>
 
 /*
  * Definition of buttons on the tablet. The ACPI index of each button
@@ -33,6 +34,12 @@ struct soc_button_info {
 	unsigned int event_code;
 	bool autorepeat;
 	bool wakeup;
+};
+
+static struct soc_button_info asus_vol_button_ACPI0011[] = {
+        { "volume_up", 0, EV_KEY, KEY_VOLUMEUP, true, false },
+        { "volume_down", 1, EV_KEY, KEY_VOLUMEDOWN, true, false },
+        { }
 };
 
 /*
@@ -150,6 +157,16 @@ static int soc_button_remove(struct platform_device *pdev)
 	return 0;
 }
 
+static const struct dmi_system_id ACPI0011_volume_adjust_only[] = {
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "UX360UA"),
+		},
+	},
+	{}
+};
+
 static int soc_button_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
@@ -165,6 +182,9 @@ static int soc_button_probe(struct platform_device *pdev)
 		return -ENODEV;
 
 	button_info = (struct soc_button_info *)id->driver_data;
+	if (dmi_check_system(ACPI0011_volume_adjust_only)) {
+		button_info = asus_vol_button_ACPI0011;
+	}
 
 	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)
@@ -201,8 +221,13 @@ static struct soc_button_info soc_button_PNP0C40[] = {
 	{ }
 };
 
+static struct soc_button_info dummy_button_ACPI0011[] = {
+	{ }
+};
+
 static const struct acpi_device_id soc_button_acpi_match[] = {
 	{ "PNP0C40", (unsigned long)soc_button_PNP0C40 },
+	{ "ACPI0011", (unsigned long)dummy_button_ACPI0011},
 	{ }
 };
 


### PR DESCRIPTION
…Down" key

ASUS UX360UA have an extra volume up/down button controlled by gpios which
are specified in ACPI0011 device. Here's the DSDT definition.

Device (BTNS)
{
    Name (_HID, "ACPI0011")  // _HID: Hardware ID
    Name (_DDN, "Generic HID over Interrupt Button Interface")  // _DDN: DOS Device Name
    Method (_CRS, 0, NotSerialized)  // _CRS: Current Resource Settings
    {
        Name (CBUF, ResourceTemplate ()
        {
            GpioInt (Edge, ActiveBoth, Exclusive, PullDefault, 0x0BB8,
                "\\_SB.PCI0.GPI0", 0x00, ResourceConsumer, ,
                )
                {   // Pin list
                    0x0000
                }
            GpioInt (Edge, ActiveBoth, Exclusive, PullDefault, 0x0BB8,
                "\\_SB.PCI0.GPI0", 0x00, ResourceConsumer, ,
                )
                {   // Pin list
                    0x0000
                }
        })
        CreateWordField (CBUF, 0x17, INT1)
        CreateWordField (CBUF, 0x3F, INT2)
        INT1 = GNUM (0x02030015)
        INT2 = GNUM (0x02030016)
        Return (CBUF) /* \_SB_.BTNS._CRS.CBUF */
    }

    Method (_STA, 0, NotSerialized)  // _STA: Status
    {
        Return (0x0F)
    }

    Name (_DSD, Package (0x02)  // _DSD: Device-Specific Data
    {
        ToUUID ("fa6bd625-9ce8-470d-a2c7-b3ca36c4282e"),
        Package (0x03)
        {
            Package (0x05)
            {
                Zero,
                One,
                Zero,
                One,
                0x0D
            },

            Package (0x05)
            {
                One,
                Zero,
                One,
                0x0C,
                0xE9
            },

            Package (0x05)
            {
                One,
                One,
                One,
                0x0C,
                0xEA
            }
        }
    })
}

GpioInt index 0 is for volume up, 1 is for volume down. Add definition for
it and it works as expected.

https://phabricator.endlessm.com/T13917

Signed-off-by: Chris Chiu <chiu@endlessm.com>