### PR TITLE
HID: multitouch: handle external buttons for Precision Touchpads

### DIFF
--- a/drivers/hid/hid-multitouch.c
+++ b/drivers/hid/hid-multitouch.c
@@ -567,6 +567,14 @@ static int mt_touch_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 
 	case HID_UP_BUTTON:
 		code = BTN_MOUSE + ((usage->hid - 1) & HID_USAGE);
+		/*
+		 * MS PTP spec says that external buttons left and right have
+		 * usages 2 and 3.
+		 */
+		if (cls->name == MT_CLS_WIN_8 &&
+		    field->application == HID_DG_TOUCHPAD &&
+		    (usage->hid & HID_USAGE) > 1)
+			code--;
 		hid_map_usage(hi, usage, bit, max, EV_KEY, code);
 		input_set_capability(hi->input, EV_KEY, code);
 		return 1;


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/windows/hardware/mt604195(v=vs.85).aspx
external buttons have some weird usage mapping:
- Button 2 Indicates Button State for external button for primary
  (default left) clicking.
- Button 3 Indicates Button State for external button for secondary
  (default right) clicking.

So in the current state, the buttons are mapped to right and middle.
Move the usage by one to correctly map the external buttons.

Signed-off-by: Benjamin Tissoires <benjamin.tissoires@redhat.com>