### PR TITLE
mmc: sdhci-acpi: support 80860F14 UID 2 SDIO bus

### DIFF
--- a/drivers/mmc/host/sdhci-acpi.c
+++ b/drivers/mmc/host/sdhci-acpi.c
@@ -328,6 +328,7 @@ static const struct sdhci_acpi_uid_slot sdhci_acpi_uids[] = {
 	{ "80865ACC", NULL, &sdhci_acpi_slot_int_emmc },
 	{ "80865AD0", NULL, &sdhci_acpi_slot_int_sdio },
 	{ "80860F14" , "1" , &sdhci_acpi_slot_int_emmc },
+	{ "80860F14" , "2" , &sdhci_acpi_slot_int_sdio },
 	{ "80860F14" , "3" , &sdhci_acpi_slot_int_sd   },
 	{ "80860F16" , NULL, &sdhci_acpi_slot_int_sd   },
 	{ "INT33BB"  , "2" , &sdhci_acpi_slot_int_sdio },


### PR DESCRIPTION
Add an entry for the SDIO bus in the ECS EF20 cherry trail laptop:

  Device (SDHB) {
    Name (_ADR, 0x00110000)
    Name (_HID, "80860F14" /* Intel Baytrail SDIO/MMC Host Controller */)
    Name (_CID, "PNP0D40" /* SDA Standard Compliant SD Host Controller */)
    Name (_DDN, "Intel(R) SDIO Controller - 80862295")
    Name (_UID, 0x02)
    Name (_HRV, One)

A SDHB device with the same _HID and _UID can also be found on other
cherry trail products like Chuwi Hi10.

Signed-off-by: Daniel Drake <drake@endlessm.com>

https://phabricator.endlessm.com/T6305