### PR TITLE
Bluetooth: hci_bcm: Add BCM2E96 device and fix GPIOs for EF20EA

### DIFF
--- a/drivers/bluetooth/hci_bcm.c
+++ b/drivers/bluetooth/hci_bcm.c
@@ -622,6 +622,10 @@ static const struct acpi_gpio_params device_wakeup_gpios = { 0, 0, false };
 static const struct acpi_gpio_params shutdown_gpios = { 1, 0, false };
 static const struct acpi_gpio_params host_wakeup_gpios = { 2, 0, false };
 
+static const struct acpi_gpio_params ecs_device_wakeup_gpios = { 1, 0, false };
+static const struct acpi_gpio_params ecs_shutdown_gpios = { 2, 0, false };
+static const struct acpi_gpio_params ecs_host_wakeup_gpios = { 0, 0, false };
+
 static const struct acpi_gpio_mapping acpi_bcm_default_gpios[] = {
 	{ "device-wakeup-gpios", &device_wakeup_gpios, 1 },
 	{ "shutdown-gpios", &shutdown_gpios, 1 },
@@ -629,8 +633,32 @@ static const struct acpi_gpio_mapping acpi_bcm_default_gpios[] = {
 	{ },
 };
 
+static const struct acpi_gpio_mapping ecs_acpi_bcm_default_gpios[] = {
+	{ "device-wakeup-gpios", &ecs_device_wakeup_gpios, 1 },
+	{ "shutdown-gpios", &ecs_shutdown_gpios, 1 },
+	{ "host-wakeup-gpios", &ecs_host_wakeup_gpios, 1 },
+	{ },
+};
+
+
 #ifdef CONFIG_ACPI
 static u8 acpi_active_low = ACPI_ACTIVE_LOW;
+
+static const struct dmi_system_id ecs_wrong_gpios_dmi_table[] = {
+	{
+		.ident = "EF20EA",
+		.matches = {
+			DMI_MATCH(DMI_PRODUCT_NAME, "EF20EA"),
+		}
+	},
+	{
+		.ident = "EF20",
+		.matches = {
+			DMI_MATCH(DMI_PRODUCT_NAME, "EF20"),
+		}
+	},
+	{ }
+};
 
 /* IRQ polarity of some chipsets are not defined correctly in ACPI table. */
 static const struct dmi_system_id bcm_wrong_irq_dmi_table[] = {
@@ -688,8 +716,12 @@ static int bcm_acpi_probe(struct bcm_device *dev)
 
 	/* Retrieve GPIO data */
 	dev->name = dev_name(&pdev->dev);
-	ret = acpi_dev_add_driver_gpios(ACPI_COMPANION(&pdev->dev),
-					acpi_bcm_default_gpios);
+	if (dmi_check_system(ecs_wrong_gpios_dmi_table))
+		ret = acpi_dev_add_driver_gpios(ACPI_COMPANION(&pdev->dev),
+						ecs_acpi_bcm_default_gpios);
+	else
+		ret = acpi_dev_add_driver_gpios(ACPI_COMPANION(&pdev->dev),
+						acpi_bcm_default_gpios);
 	if (ret)
 		return ret;
 
@@ -828,6 +860,7 @@ static const struct acpi_device_id bcm_acpi_match[] = {
 	{ "BCM2E71", 0 },
 	{ "BCM2E7B", 0 },
 	{ "BCM2E7C", 0 },
+	{ "BCM2E96", 0 },
 	{ },
 };
 MODULE_DEVICE_TABLE(acpi, bcm_acpi_match);


### PR DESCRIPTION
Add the BCM2E96 ID used by the ECS EF20 laptop.

 hci0: BCM: chip id 82
 hci0: BCM43341B0 (002.001.014) build 0000
 hci0: BCM (002.001.014) build 0158

According to the vendor kernel, the GPIOs to use here are ordered
differently from the way this driver behaves as standard.
We also apply the modified order for this product.

It might be more correct to modify the BIOS to list the correct order,
although a comment in the vendor kernel suggests that this change
may be standard for all BCM2E96 devices.

Bluetooth seems to work on EF20 with or without this, but I think it's
working more reliably with this change and also the host wakeup
interrupts are now arriving.

https://phabricator.endlessm.com/T10572

Signed-off-by: Carlo Caione <carlo@endlessm.com>