### PR TITLE
i2c-hid: Disable IRQ before freeing buffers

### DIFF
--- a/drivers/hid/i2c-hid/i2c-hid.c
+++ b/drivers/hid/i2c-hid/i2c-hid.c
@@ -716,9 +716,11 @@ static int i2c_hid_start(struct hid_device *hid)
 	i2c_hid_find_max_report(hid, HID_FEATURE_REPORT, &bufsize);
 
 	if (bufsize > ihid->bufsize) {
+		disable_irq(ihid->irq);
 		i2c_hid_free_buffers(ihid);
 
 		ret = i2c_hid_alloc_buffers(ihid, bufsize);
+		enable_irq(ihid->irq);
 
 		if (ret)
 			return ret;


### PR DESCRIPTION
It may be necessary to allocate bigger buffers in i2c_hid_start() if the
report size of a device is bigger than the buffers allocated on probe.
When this happens ihid->irq is already running, so it needs to be
disabled otherwise ihid->inbuf may be modified after freed if
i2c_master_recv() in i2c_hid_get_input() is called immediatelly before
i2c_hid_free_buffers() in i2c_hid_start().

This problem has been observed on an Asus UX360UA laptop which has an
I2C touchpad, and this change makes the problem go away.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T14091