### PR TITLE
asus-wmi: Add quirk_no_rfkill for the Asus UX430UQ

### DIFF
--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -405,6 +405,15 @@ static const struct dmi_system_id asus_quirks[] = {
 		},
 		.driver_data = &quirk_no_rfkill,
 	},
+	{
+		.callback = dmi_matched,
+		.ident = "ASUSTeK COMPUTER INC. UX430UQ",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "UX430UQ"),
+		},
+		.driver_data = &quirk_no_rfkill,
+	},
 	{},
 };
 


### PR DESCRIPTION
Apply the quirk_no_rfkill for Asus UX430UQ has airplane-mode indicator.
It prevents asus-wmi from registering RFKill switches at all and allows
asus-wireless to drive the LED through the ASHS ACPI device.

https://phabricator.endlessm.com/T14464

Signed-off-by: Chris Chiu <chiu@endlessm.com>