### PR TITLE
ath9k: add a norfkill_gpio quirk for Acer Aspire ES1-421

### DIFF
--- a/drivers/net/wireless/ath/ath9k/hw.c
+++ b/drivers/net/wireless/ath/ath9k/hw.c
@@ -22,6 +22,7 @@
 #include <linux/etherdevice.h>
 #include <linux/gpio.h>
 #include <asm/unaligned.h>
+#include <linux/dmi.h>
 
 #include "hw.h"
 #include "hw-ops.h"
@@ -2438,6 +2439,17 @@ static void ath9k_gpio_cap_init(struct ath_hw *ah)
 	}
 }
 
+static const struct dmi_system_id dmi_norfkill_gpio[] = {
+	{
+		.ident = "Acer Aspire ES1-421",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire ES1-421"),
+		},
+	},
+	{}
+};
+
 int ath9k_hw_fill_cap_info(struct ath_hw *ah)
 {
 	struct ath9k_hw_capabilities *pCap = &ah->caps;
@@ -2546,7 +2558,9 @@ int ath9k_hw_fill_cap_info(struct ath_hw *ah)
 		ah->rfkill_polarity =
 			MS(ah->rfsilent, EEP_RFSILENT_POLARITY);
 
-		pCap->hw_caps |= ATH9K_HW_CAP_RFSILENT;
+		if (!dmi_check_system(dmi_norfkill_gpio)) {
+			pCap->hw_caps |= ATH9K_HW_CAP_RFSILENT;
+		}
 	}
 #endif
 	if (AR_SREV_9271(ah) || AR_SREV_9300_20_OR_LATER(ah))


### PR DESCRIPTION
The Acer Aspire ES1-421 rfkill_gpio seems connet to something
unknown. The NFA335 module can work on first boot, then goes to
hardware-disabled after suspend/resume. And itt doesn't come back
even after reboot. This commit ignore the rfkill_gpio input based
on DMI info.

https://phabricator.endlessm.com/T14777

Signed-off-by: Chris Chiu <chiu@endlessm.com>