### PR TITLE
PCI: Disable AER for Skylake+Realtek systems on ASUS D520MT-K

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2338,6 +2338,7 @@ static void quirk_disable_rtl_aspm(struct pci_dev *dev)
 	}
 }
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_rtl_aspm);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa117, quirk_disable_rtl_aspm);
 
 /*
  * The APC bridge device in AMD 780 family northbridges has some random


### PR DESCRIPTION
It's also a Realtek RTL8821AE card on Skylake which cause PCIe AER
error spam. However, it happen on different PCIe root port.

pcieport 0000:00:1c.7: PCIe Bus Error: severity=Corrected, type=Physical Layer, id=00e5(Receiver ID)
pcieport 0000:00:1c.7:   device [8086:a117] error status/mask=00000001/00002000
pcieport 0000:00:1c.7:    [ 0] Receiver Error
pcieport 0000:00:1c.7: AER: Corrected error received: id=00e5
pcieport 0000:00:1c.7: can't find device of ID00e5
pcieport 0000:00:1c.7: AER: Corrected error received: id=00e5
pcieport 0000:00:1c.7: can't find device of ID00e5

Apply the same workaround quirk_disable_rtl_aspm() on the problematic
PCI vendor/device ID.