### PR TITLE
acer-wmi: Use acpi_dev_found() in acer_wmi_get_handle()

### DIFF
--- a/drivers/platform/x86/acer-wmi.c
+++ b/drivers/platform/x86/acer-wmi.c
@@ -1863,6 +1863,9 @@ static int __init acer_wmi_get_handle(const char *name, const char *prop,
 
 	BUG_ON(!name || !ah);
 
+	if (!acpi_dev_found(prop))
+		return -ENODEV;
+
 	handle = NULL;
 	status = acpi_get_devices(prop, acer_wmi_get_handle_cb,
 					(void *)name, &handle);


### PR DESCRIPTION
Use acpi_dev_found() before acpi_get_devices() if the particular
ACPI device not even exist. On the Acer TravelMate P449-G2-MG we
have observed the acpi_get_devices() here causes the system hang.
There's no such accel device on the machine and it does not happen
on other Acer machines in my hands. Additional check without
function change should be good to have.

https://phabricator.endlessm.com/T15061

Signed-off-by: Chris Chiu <chiu@endless.com>