### PR TITLE
sdhci-pci: use SDHCI_QUIRK2_BROKEN_HS200 for Acer ApolloLake models

### DIFF
--- a/drivers/mmc/host/sdhci-pci-core.c
+++ b/drivers/mmc/host/sdhci-pci-core.c
@@ -391,6 +391,16 @@ static int byt_sd_probe_slot(struct sdhci_pci_slot *slot)
 	return 0;
 }
 
+static const struct sdhci_pci_fixes sdhci_acer_apl_emmc = {
+	.allow_runtime_pm = true,
+	.probe_slot	= byt_emmc_probe_slot,
+	.quirks		= SDHCI_QUIRK_NO_ENDATTR_IN_NOPDESC,
+	.quirks2	= SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			  SDHCI_QUIRK2_BROKEN_HS200 |
+			  SDHCI_QUIRK2_CAPS_BIT63_FOR_HS400 |
+			  SDHCI_QUIRK2_STOP_WITH_TC,
+};
+
 static const struct sdhci_pci_fixes sdhci_intel_byt_emmc = {
 	.allow_runtime_pm = true,
 	.probe_slot	= byt_emmc_probe_slot,
@@ -1188,6 +1198,14 @@ static const struct pci_device_id pci_ids[] = {
 		.subvendor	= PCI_ANY_ID,
 		.subdevice	= PCI_ANY_ID,
 		.driver_data	= (kernel_ulong_t)&sdhci_intel_byt_sd,
+	},
+
+	{
+		.vendor		= PCI_VENDOR_ID_INTEL,
+		.device		= PCI_DEVICE_ID_INTEL_APL_EMMC,
+		.subvendor	= PCI_VENDOR_ID_AI,
+		.subdevice	= 0x110e,
+		.driver_data	= (kernel_ulong_t)&sdhci_acer_apl_emmc,
 	},
 
 	{


### PR DESCRIPTION
We found the Intel SD Host controller(5acc) fail to switch to HS200
mode on Acer ApolloLake models. So the internal emmc storage can not
be detected. Add SDHCI_QUIRK2_BROKEN_HS200 for particular subsystem
vendor/device id

https://phabricator.endlessm.com/T14845

Signed-off-by: Chris Chiu <chiu@endlessm.com>