### PR TITLE
i915: quirk Weibu F3C DP-to-VGA setup

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -27,6 +27,7 @@
  *
  */
 
+#include <linux/dmi.h>
 #include <linux/acpi.h>
 #include <linux/device.h>
 #include <linux/oom.h>
@@ -1165,6 +1166,24 @@ static void i915_driver_unregister(struct drm_i915_private *dev_priv)
 	i915_gem_shrinker_cleanup(dev_priv);
 }
 
+static const struct dmi_system_id weibu_f3c[] = {
+	{
+		.ident = "Weibu F3C",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Weibu"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "F3C"),
+		},
+	},
+	{
+		.ident = "Endless EE-200",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Endless"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "EE-200"),
+		},
+	},
+	{ }
+};
+
 /**
  * i915_driver_load - setup chip and create an initial config
  * @dev: DRM device
@@ -1197,6 +1216,7 @@ int i915_driver_load(struct pci_dev *pdev, const struct pci_device_id *ent)
 
 	dev_priv->drm.pdev = pdev;
 	dev_priv->drm.dev_private = dev_priv;
+	dev_priv->quirk_weibu_f3c = !!dmi_check_system(weibu_f3c);
 
 	ret = pci_enable_device(pdev);
 	if (ret)

--- a/drivers/gpu/drm/i915/i915_drv.h
+++ b/drivers/gpu/drm/i915/i915_drv.h
@@ -2111,6 +2111,17 @@ struct drm_i915_private {
 	 * NOTE: This is the dri1/ums dungeon, don't add stuff here. Your patch
 	 * will be rejected. Instead look for a better place.
 	 */
+
+	/* The Weibu F3C has a DP-to-VGA converter chip to enable the VGA port.
+	 * However the VBT lists it an internal eDP panel, and we don't know
+	 * how to access the VGA hotplug pin on the converter chip, so we
+	 * resort to polling the EDID and updating connector status based on
+	 * that.
+	 *
+	 * This flag should probably be kept inside intel_dp but we put it
+	 * here in the interests of making this patch as least invasive as
+	 * possible. */
+	bool quirk_weibu_f3c;
 };
 
 static inline struct drm_i915_private *to_i915(const struct drm_device *dev)

--- a/drivers/gpu/drm/i915/intel_bios.c
+++ b/drivers/gpu/drm/i915/intel_bios.c
@@ -1658,6 +1658,12 @@ bool intel_bios_is_port_edp(struct drm_i915_private *dev_priv, enum port port)
 	};
 	int i;
 
+	/* Quirky VBT defines eDP internal panel instead of DP. We set it to
+	 * DP so that Linux queries the EDID and sets supported display modes
+	 * based on that, ignoring the bogus panel definition. */
+	if (dev_priv->quirk_weibu_f3c)
+		return false;
+
 	if (!dev_priv->vbt.child_dev_num)
 		return false;
 

--- a/drivers/gpu/drm/i915/intel_dp.c
+++ b/drivers/gpu/drm/i915/intel_dp.c
@@ -4360,6 +4360,7 @@ intel_dp_long_pulse(struct intel_connector *intel_connector)
 	struct intel_digital_port *intel_dig_port = dp_to_dig_port(intel_dp);
 	struct intel_encoder *intel_encoder = &intel_dig_port->base;
 	struct drm_device *dev = connector->dev;
+	struct drm_i915_private *dev_priv = to_i915(dev);
 	enum drm_connector_status status;
 	enum intel_display_power_domain power_domain;
 	u8 sink_irq_vector = 0;
@@ -4426,6 +4427,11 @@ intel_dp_long_pulse(struct intel_connector *intel_connector)
 		drm_modeset_lock(&dev->mode_config.connection_mutex, NULL);
 		intel_dp_check_link_status(intel_dp);
 		drm_modeset_unlock(&dev->mode_config.connection_mutex);
+
+		/* Poll the EDID to update connection state */
+		if (dev_priv->quirk_weibu_f3c)
+			intel_dp_set_edid(intel_dp);
+
 		goto out;
 	}
 
@@ -4470,6 +4476,7 @@ intel_dp_detect(struct drm_connector *connector, bool force)
 {
 	struct intel_dp *intel_dp = intel_attached_dp(connector);
 	enum drm_connector_status status = connector->status;
+	struct drm_i915_private *dev_priv = to_i915(connector->dev);
 
 	DRM_DEBUG_KMS("[CONNECTOR:%d:%s]\n",
 		      connector->base.id, connector->name);
@@ -4479,6 +4486,11 @@ intel_dp_detect(struct drm_connector *connector, bool force)
 		status = intel_dp_long_pulse(intel_dp->attached_connector);
 
 	intel_dp->detect_done = false;
+
+	/* Quirk to set status as disconnected if we didn't get an EDID */
+	if (dev_priv->quirk_weibu_f3c &&
+	    to_intel_connector(connector)->detect_edid == NULL)
+		status = connector_status_disconnected;
 
 	return status;
 }
@@ -5722,6 +5734,12 @@ intel_dp_init_connector(struct intel_digital_port *intel_dig_port,
 	DRM_DEBUG_KMS("Adding %s connector on port %c\n",
 			type == DRM_MODE_CONNECTOR_eDP ? "eDP" : "DP",
 			port_name(port));
+
+	/* Poll the EDID to update connection state, since we don't know
+	 * how to access the hotplug state */
+	if (dev_priv->quirk_weibu_f3c)
+		intel_connector->polled = DRM_CONNECTOR_POLL_CONNECT |
+					  DRM_CONNECTOR_POLL_DISCONNECT;
 
 	drm_connector_init(dev, connector, &intel_dp_connector_funcs, type);
 	drm_connector_helper_add(connector, &intel_dp_connector_helper_funcs);


### PR DESCRIPTION
The Weibu F3C has a VGA port, enabled through an onboard PS8613
DP-to-VGA converter chip.

However the BIOS describes the DP interface from the SoC as being
hooked up to an internal 1366x768 LCD panel over eDP, with a backlight.

Until we get a fixed BIOS, force it to be detected as DP. That way
we ignore the panel definition, don't register a backlight device,
and we request the EDID over the AUX pins in order to get display modes.

We also have a problem with presence detection and hotplug. The SoC
detects the DP connection as always connected (since the chip is always
there). The PS8613 does have a DP_HPD pin that looks like it could tell
us when the VGA monitor is present and hotplugged, but we don't know how
that is hooked up to the SoC.

In order to work around this limitation, we poll the status every 10
seconds. We force a re-read of the EDID even when there is no connector
state change, and we update the connector status to disconnected if we
fail to read the EDID.

https://phabricator.endlessm.com/T14620