### PR TITLE
drm/nouveau: Disable runtime pm on more Asus laptops

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1102,6 +1102,27 @@ static const struct dmi_system_id nouveau_rpm_0[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "X756UQK"),
 		},
 	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. GL552VXK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "GL552VXK"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. K401UQK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "K401UQK"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. X550VXK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X550VXK"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
The Asus GL552VXK/X550VXK/K401UQK has two video cards (Intel+NVIDIA). They
suffer the same runtime pm problem as X756UQK but it happens during boot
from HDD/USB. Apply the same quirk until there's a upstream fix

Signed-off-by: Chris Chiu <chiu@endlessm.com>

https://phabricator.endlessm.com/T15697