### PR TITLE
Revert "intel_idle: Disable on Asus N552VW"

### DIFF
--- a/drivers/idle/intel_idle.c
+++ b/drivers/idle/intel_idle.c
@@ -1090,16 +1090,6 @@ static const struct x86_cpu_id intel_idle_ids[] __initconst = {
 	{}
 };
 
-static const struct dmi_system_id idle_blacklist[] __initconst = {
-	{
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "N552VW"),
-		},
-	},
-	{}
-};
-
 static const struct dmi_system_id idle_cstate[] __initconst = {
 	{
 		.matches = {
@@ -1127,11 +1117,6 @@ static int __init intel_idle_probe(void)
 	if (max_cstate == 0) {
 		pr_debug(PREFIX "disabled\n");
 		return -EPERM;
-	}
-
-	if (dmi_check_system(idle_blacklist)) {
-		pr_debug(PREFIX "disabled on this hardware model\n");
-		return -ENODEV;
 	}
 
 	if (dmi_check_system(idle_cstate)) {


### PR DESCRIPTION
This reverts commit 983d29bce13fbc64135fa4650f87ba42d5e16a14.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T15710