### PR TITLE
PCI: Disable AER for Skylake+Realtek systems

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2350,6 +2350,7 @@ static void quirk_disable_rtl_aspm(struct pci_dev *dev)
 }
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa117, quirk_disable_rtl_aspm);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa115, quirk_disable_rtl_aspm);
 
 /*
  * The APC bridge device in AMD 780 family northbridges has some random


### PR DESCRIPTION
Apply the quirk_disable_rtl_aspm for the same combination found in
ASUS D320SF-K.

 pcieport 0000:00:1c.0: PCIe Bus Error: severity=Corrected, type=Physical La
yer, id=00e0(Receiver ID)
 pcieport 0000:00:1c.0:   device [8086:a115] error status/mask=00000001/0000
2000
 pcieport 0000:00:1c.0:    [ 0] Receiver Error
 pcieport 0000:00:1c.0: AER: Corrected error received: id=00e0
 pcieport 0000:00:1c.0: can't find device of ID00e0
 pcieport 0000:00:1c.0: AER: Corrected error received: id=00e0
 pcieport 0000:00:1c.0: can't find device of ID00e0

https://phabricator.endlessm.com/T15946

Signed-off-by: Chris Chiu <chiu@endlessm.com>