### PR TITLE
PCI: Disable AER for Kabylake+Realtek systems

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2351,6 +2351,7 @@ static void quirk_disable_rtl_aspm(struct pci_dev *dev)
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa117, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa115, quirk_disable_rtl_aspm);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa112, quirk_disable_rtl_aspm);
 
 /*
  * The APC bridge device in AMD 780 family northbridges has some random


### PR DESCRIPTION
Apply the quirk_disable_rtl_aspm for RTL8821AE on Kabylake PCI bridge
in ASUS X550VX. It whould cause lots of applications not responding.

 pcieport 0000:00:1c.2: PCIe Bus Error: severity=Corrected, type=Physical Layer, id=00e2(Receiver ID)
 pcieport 0000:00:1c.2:   device [8086:a112] error status/mask=00000001/00002000
 pcieport 0000:00:1c.2:    [ 0] Receiver Error
 pcieport 0000:00:1c.2: AER: Corrected error received: id=00e2
 pcieport 0000:00:1c.2: can't find device of ID00e2
 pcieport 0000:00:1c.2: AER: Corrected error received: id=00e2
 pcieport 0000:00:1c.2: can't find device of ID00e2

https://phabricator.endlessm.com/T16032

Signed-off-by: Chris Chiu <chiu@endlessm.com>