### PR TITLE
T16069: version the dependency between -extra and -signed-image

### DIFF
--- a/debian.master/control.d/flavour-control.stub
+++ b/debian.master/control.d/flavour-control.stub
@@ -53,7 +53,7 @@ Build-Profiles: <!stage1>
 Architecture: ARCH
 Section: kernel
 Priority: optional
-Depends: ${misc:Depends}, ${shlibs:Depends}, linux-signed-image-PKGVER-ABINUM-FLAVOUR [amd64] | linux-image-PKGVER-ABINUM-FLAVOUR, crda | wireless-crda
+Depends: ${misc:Depends}, ${shlibs:Depends}, linux-signed-image-PKGVER-ABINUM-FLAVOUR (= ${source:Version}) [amd64] | linux-image-PKGVER-ABINUM-FLAVOUR, crda | wireless-crda
 Description: Linux kernel extra modules for version PKGVER on DESC
  This package contains the Linux kernel extra modules for version PKGVER on
  DESC.


### PR DESCRIPTION
Add a version to the -extra package dependency on -signed-image. When secure boot is enabled, it's not possible to load the modules in a kernel build at a different time because a different transient module signing key is used for each build.

https://phabricator.endlessm.com/T16069