### PR TITLE
ACPI / EC: Fix media keys not working problem on some Asus X580VD

### DIFF
--- a/drivers/acpi/ec.c
+++ b/drivers/acpi/ec.c
@@ -1816,6 +1816,10 @@ static struct dmi_system_id ec_dmi_table[] __initdata = {
 	ec_honor_ecdt_gpe, "ASUSTeK COMPUTER INC. FX502VE", {
 	DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
 	DMI_MATCH(DMI_PRODUCT_NAME, "FX502VE"),}, NULL},
+	{
+	ec_honor_ecdt_gpe, "ASUSTeK COMPUTER INC. X580VD", {
+	DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+	DMI_MATCH(DMI_PRODUCT_NAME, "X580VD"),}, NULL},
 	{},
 };
 


### PR DESCRIPTION
Apply the same DMI quirk in last commit to fix the incorrect GPE number
defined in DSDT on EC device for Asus X580VD

https://phabricator.endlessm.com/T16722

Signed-off-by: Chris Chiu <chiu@endlessm.com>