### PR TITLE
ACPI / EC: Fix NULL reference of boot_ec caused by the DMI quirk

### DIFF
--- a/drivers/acpi/ec.c
+++ b/drivers/acpi/ec.c
@@ -1282,7 +1282,10 @@ ec_parse_device(acpi_handle handle, u32 Level, void *context, void **retval)
 		 * Always inherit the gpe number setting from first
                  * boot_ec.
                  */
-		ec->gpe = boot_ec->gpe;
+                /* ec has been assigned with original boot_ec here,
+                 * leave it as it is. boot_ec and first_ec is cleared
+                 * to NULL at acpi_ec_alloc.
+                 */
 	} else {
 		/* Get GPE bit assignment (EC events). */
 		/* TODO: Add support for _GPE returning a package */


### PR DESCRIPTION
The boot_ec is handled differently in kernel 4.10 and 4.8. The DMI
quirk in 4002b744054d5d79c302a95ba67562209ce289dd is originally
designed for the ec driver on kernel 4.10. Fix the NULL boot_ec
and keep the DMI quirk working.

https://phabricator.endlessm.com/T16834

Signed-off-by: Chris Chiu <chiu@endlessm.com>