### PR TITLE
T17116 

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
@@ -40,6 +40,7 @@
 #include <linux/pm_runtime.h>
 #include <linux/vga_switcheroo.h>
 #include "drm_crtc_helper.h"
+#include <linux/dmi.h>
 
 #include "amdgpu.h"
 #include "amdgpu_irq.h"
@@ -429,6 +430,24 @@ static const struct pci_device_id pciidlist[] = {
 
 MODULE_DEVICE_TABLE(pci, pciidlist);
 
+static const struct dmi_system_id dmi_no_modeset[] = {
+       {
+               .ident = "Acer Aspire A515-41G",
+               .matches = {
+                       DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+                       DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A515-41G"),
+               },
+       },
+       {
+               .ident = "Acer Nitro AN515-41",
+               .matches = {
+                       DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+                       DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN515-41"),
+               },
+       },
+       {}
+};
+
 static struct drm_driver kms_driver;
 
 static int amdgpu_kick_out_firmware_fb(struct pci_dev *pdev)
@@ -457,6 +476,10 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
 {
 	unsigned long flags = ent->driver_data;
 	int ret;
+
+	if (dmi_check_system(dmi_no_modeset)) {
+                return -ENODEV;
+	}
 
 	if ((flags & AMD_EXP_HW_SUPPORT) && !amdgpu_exp_hw_support) {
 		DRM_INFO("This hardware requires experimental hardware support.\n"

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c
@@ -35,31 +35,12 @@
 #include <linux/slab.h>
 #include <linux/pm_runtime.h>
 #include "amdgpu_amdkfd.h"
-#include <linux/dmi.h>
 
 #if defined(CONFIG_VGA_SWITCHEROO)
 bool amdgpu_has_atpx(void);
 #else
 static inline bool amdgpu_has_atpx(void) { return false; }
 #endif
-
-static const struct dmi_system_id dmi_no_modeset[] = {
-	{
-		.ident = "Acer Aspire A515-41G",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A515-41G"),
-		},
-	},
-	{
-		.ident = "Acer Nitro AN515-41",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN515-41"),
-		},
-	},
-	{}
-};
 
 /**
  * amdgpu_driver_unload_kms - Main unload function for KMS.
@@ -124,11 +105,6 @@ int amdgpu_driver_load_kms(struct drm_device *dev, unsigned long flags)
 	     amdgpu_has_atpx_dgpu_power_cntl()) &&
 	    ((flags & AMD_IS_APU) == 0))
 		flags |= AMD_IS_PX;
-
-	if (dmi_check_system(dmi_no_modeset)) {
-		r = -EINVAL;
-		goto out;
-	}
 
 	/* amdgpu_device_init should report only fatal error
 	 * like memory allocation failure or iomapping failure,


### PR DESCRIPTION
Revert old commit "drm/amdgpu: disable driver loading for particular Acer models" which only works in Legacy mode. Move the DMI check to amdgpu_pci_probe but don't know it there's still X509 certificate issue.