### PR TITLE
ACPI / EC: Fix suspend on lid closing caused by wrong GPE in DSDT

### DIFF
--- a/drivers/acpi/ec.c
+++ b/drivers/acpi/ec.c
@@ -1793,6 +1793,10 @@ static struct dmi_system_id ec_dmi_table[] __initdata = {
 	ec_honor_ecdt_gpe, "ASUSTeK COMPUTER INC. X580VD", {
 	DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
 	DMI_MATCH(DMI_PRODUCT_NAME, "X580VD"),}, NULL},
+	{
+	ec_honor_ecdt_gpe, "ASUSTeK COMPUTER INC. GL702VMK", {
+	DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+	DMI_MATCH(DMI_PRODUCT_NAME, "GL702VMK"),}, NULL},
 	{},
 };
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T17326