### PR TITLE
Disable nouveau on the Acer Aspire Z20-730

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1116,6 +1116,13 @@ static const struct dmi_system_id nouveau_modeset_0[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "N552VW"),
 		},
 	},
+	{
+		.ident = "Acer Aspire Z20-730",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire Z20-730"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
The Acer Aspire Z20-730 has two video cards (Intel+NVIDIA), the NVIDIA
(GM108) will hit kernel panic during boot even with the latest nouveau
driver.

Disable it for now, and revisit later for a proper fix, as some future
machines might depend on it.

Signed-off-by: Chris Chiu <chiu@endlessm.com>

https://phabricator.endlessm.com/T17225