### PR TITLE
PCI: Disable AER for Skylake/Kabylake with Realtek for ASUS D830MT/D6…

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2375,6 +2375,7 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa117, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa115, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa112, quirk_disable_rtl_aspm);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa297, quirk_disable_rtl_aspm);
 
 /*
  * The APC bridge device in AMD 780 family northbridges has some random


### PR DESCRIPTION
…30MT

Apply the same quirk_disable_rtl_aspm() for ASUS D830MT/D630MT which
have the same huge PCIe AER error spam.

https://phabricator.endlessm.com/T17655

Signed-off-by: Chris Chiu <chiu@endlessm.com>