### PR TITLE
Build linux-libc-dev package on ARM

### DIFF
--- a/debian.master/rules.d/armhf.mk
+++ b/debian.master/rules.d/armhf.mk
@@ -2,7 +2,7 @@ human_arch	= ARM (hard float)
 build_arch	= arm
 header_arch	= arm
 defconfig	= defconfig
-flavours	= generic generic-lpae
+flavours	=
 build_image	= zImage
 kernel_file	= arch/$(build_arch)/boot/zImage
 install_file	= vmlinuz
@@ -10,7 +10,7 @@ no_dumpfile	= true
 
 loader		= grub
 
-do_tools_usbip  = true
+do_tools_usbip  = false
 do_tools_cpupower = true
 do_tools_perf	= true
 


### PR DESCRIPTION
This is a dependency of glibc. We can build the headers/tools/etc
packages without actually building the kernel.

usbip had to be disabled since it depends on a header that we don't
currently ship. It could be enabled in future once we have
"bootstrapped" with this change that will get new headers in place.

https://phabricator.endlessm.com/T17739