### PR TITLE
drm/nouveau/fb/gf100-: Fix 32 bit wraparound in new ram detection

### DIFF
--- a/drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgf100.c
+++ b/drivers/gpu/drm/nouveau/nvkm/subdev/fb/ramgf100.c
@@ -589,7 +589,7 @@ gf100_ram_ctor(const struct nvkm_ram_func *func, struct nvkm_fb *fb,
 			nvkm_debug(subdev, "FBP %d: %4d MiB, %d LTC(s)\n",
 				   fbp, size, ltcs);
 			lcomm  = min(lcomm, (u64)(size / ltcs) << 20);
-			total += size << 20;
+			total += (u64) size << 20;
 			ltcn  += ltcs;
 		} else {
 			nvkm_debug(subdev, "FBP %d: disabled\n", fbp);


### PR DESCRIPTION
A missing u64 cast causes a 32-Bit wraparound from
4096 MiB to 0 MiB and therefore total 0 MiB VRAM detected
if card has 4096 Mib per FBP.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>
Reviewed-by: Karol Herbst <karolherbst@gmail.com>
Signed-off-by: Ben Skeggs <bskeggs@redhat.com>

https://phabricator.endlessm.com/T18047