### PR TITLE
nouveau/GP107: Enable noaccel quirk for Acer Aspire A717-71G

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -178,6 +178,17 @@ nouveau_accel_fini(struct nouveau_drm *drm)
 		nouveau_fence(drm)->dtor(drm);
 }
 
+static const struct dmi_system_id noaccel_quirk[] = {
+	{
+		.ident = "Aspire A717-71G",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A717-71G"),
+		},
+	},
+	{ }
+};
+
 static void
 nouveau_accel_init(struct nouveau_drm *drm)
 {
@@ -185,6 +196,8 @@ nouveau_accel_init(struct nouveau_drm *drm)
 	struct nvif_sclass *sclass;
 	u32 arg0, arg1;
 	int ret, i, n;
+
+	nouveau_noaccel = !!dmi_check_system(noaccel_quirk);
 
 	if (nouveau_noaccel)
 		return;


### PR DESCRIPTION
https://phabricator.endlessm.com/T18168