### PR TITLE
drm/nouveau: Disable runtime pm on Asus Notebooks with NV GP107

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -435,6 +435,17 @@ nouveau_get_hdmi_dev(struct nouveau_drm *drm)
 	}
 }
 
+static const struct dmi_system_id gp107_runpm_blacklist[] = {
+	{
+                .ident = "ASUS",
+                .matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_CHASSIS_TYPE, "10"), /* Notebook */
+                },
+        },
+	{ }
+};
+
 static int
 nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 {
@@ -466,6 +477,10 @@ nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 	 */
 	if (drm->client.device.info.chipset == 0xc1)
 		nvif_mask(&drm->client.device.object, 0x00088080, 0x00000800, 0x00000000);
+
+	if (drm->client.device.info.chipset == 0x137 &&
+	    dmi_check_system(gp107_runpm_blacklist))
+		nouveau_runtime_pm = 0;
 
 	nouveau_vga_init(drm);
 


### PR DESCRIPTION
The Asus FX502VD/VE, X580VD and more models with NVIDIA GTX1050(Ti)
has a problem with the interaction between runtime pm and suspend/resume
which leads to the machine hanging on boot/shutdown. This commit
disables runtime pm for all Asus Notebooks with the display chip
NV GP107.

It has to be reverted once if there's a upstream fix.

https://phabricator.endlessm.com/T17322

Signed-off-by: Chris Chiu <chiu@endlessm.com>