### PR TITLE
Rever old noaccel quirk for Acer A717-71G and enable new quirk for Acer Notebooks

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -433,6 +433,17 @@ static const struct dmi_system_id gp107_runpm_blacklist[] = {
 	{ }
 };
 
+static const struct dmi_system_id gp107_accel_blacklist[] = {
+	{
+                .ident = "Acer",
+                .matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_CHASSIS_TYPE, "10"), /* Notebook */
+                },
+        },
+	{ }
+};
+
 static int
 nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 {
@@ -468,6 +479,10 @@ nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 	if (drm->client.device.info.chipset == 0x137 &&
 	    dmi_check_system(gp107_runpm_blacklist))
 		nouveau_runtime_pm = 0;
+
+	if (drm->client.device.info.chipset == 0x137 &&
+	    dmi_check_system(gp107_accel_blacklist))
+		nouveau_noaccel = 1;
 
 	nouveau_vga_init(drm);
 

--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -178,17 +178,6 @@ nouveau_accel_fini(struct nouveau_drm *drm)
 		nouveau_fence(drm)->dtor(drm);
 }
 
-static const struct dmi_system_id noaccel_quirk[] = {
-	{
-		.ident = "Aspire A717-71G",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A717-71G"),
-		},
-	},
-	{ }
-};
-
 static void
 nouveau_accel_init(struct nouveau_drm *drm)
 {
@@ -196,8 +185,6 @@ nouveau_accel_init(struct nouveau_drm *drm)
 	struct nvif_sclass *sclass;
 	u32 arg0, arg1;
 	int ret, i, n;
-
-	nouveau_noaccel = !!dmi_check_system(noaccel_quirk);
 
 	if (nouveau_noaccel)
 		return;


### PR DESCRIPTION
All laptops ship with NVIDIA GeForce GTX 1050 (Ti) requires passing
'nouveau.noaccel=1' at boot to have it working correctly and avoid
boot or shutdown failure.

With this patch we introduce a new quirk and link it to all Acer
laptops with GP107 to automatically enable this module parameter.

phabricator: https://phabricator.endlessm.com/T18500

Signed-off-by: Chris Chiu <chiu@endlessm.com>