### PR TITLE
PCI: Disable AER for Skylake/Kabylake with Realtek for ASUS D830SF

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2373,6 +2373,7 @@ static void quirk_disable_rtl_aspm(struct pci_dev *dev)
 }
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x9d15, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa117, quirk_disable_rtl_aspm);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa116, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa115, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa112, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa297, quirk_disable_rtl_aspm);


### PR DESCRIPTION
Apply the same quirk_disable_rtl_aspm() for ASUS D830SF which have
the same huge PCIe AER error spam.

https://phabricator.endlessm.com/T18688

Signed-off-by: Chris Chiu <chiu@endlessm.com>