### PR TITLE
PCI: Disable MSI for Apollolake with QCA9565 systems

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2377,6 +2377,28 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa115, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa112, quirk_disable_rtl_aspm);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa297, quirk_disable_rtl_aspm);
 
+/* Qualcomm Atheros wireless module NFA335(AR9565) on Apollolake has problem
+ * supporting INTx interrupt mechanism. However, current ath9k driver only
+ * support INTx. Before someone contribute the MSI support on ath9k, MSI need
+ * to be disabled for specific combination.
+ */
+static void quirk_disable_ath9k_msi(struct pci_dev *dev)
+{
+	struct pci_dev *child;
+
+	if (!dev->subordinate)
+		return;
+
+	list_for_each_entry(child, &dev->subordinate->devices, bus_list) {
+		if (child->vendor == 0x168c && child->device == 0x0036) {
+			dev_warn(&child->dev, "Apollolake; disabling MSI\n");
+			pci_no_msi();
+			return;
+		}
+	}
+}
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x5adb, quirk_disable_ath9k_msi);
+
 /*
  * The APC bridge device in AMD 780 family northbridges has some random
  * OEM subsystem ID in its vendor ID register (erratum 18), so instead


### PR DESCRIPTION
It's been reported on lots of Acer laptops that NFA335(QCA AR9565)
module fail connecting wifi. From the /proc/interrupts, there's no
interrupt count at all on interrupt named ath9k. Tried on Intel/AMD
platforms, the NFA335 module only fails connecting on Apollolake.

Apollolake is known to have problem supporting INTx interrupt. However,
current ath9k driver only supports INTx mechanism and no well support
for PCI MSI/MSI-X. Disable MSI on the specific combination Apollolake
with QCA9565 to make ath9k interrupt work.

https://phabricator.endlessm.com/T16988

Signed-off-by: Chris Chiu <chiu@endlessm.com>