### PR TITLE
USB: Add device quirk for Huawei LTE module on Acer laptop

### DIFF
--- a/drivers/usb/core/hub.c
+++ b/drivers/usb/core/hub.c
@@ -3162,6 +3162,10 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)
 			goto err_lpm3;
 	}
 
+	if (udev->quirks & USB_QUIRK_DISCONNECT_SUSPEND) {
+		usb_clear_port_feature(hub->hdev, port1, USB_PORT_FEAT_ENABLE);
+	}
+
 	/* see 7.1.7.6 */
 	if (hub_is_superspeed(hub->hdev))
 		status = hub_set_port_link_state(hub, port1, USB_SS_PORT_LS_U3);

--- a/drivers/usb/core/quirks.c
+++ b/drivers/usb/core/quirks.c
@@ -199,6 +199,10 @@ static const struct usb_device_id usb_quirk_list[] = {
 	{ USB_DEVICE(0x10d6, 0x2200), .driver_info =
 			USB_QUIRK_STRING_FETCH_255 },
 
+	/* Huawei 4G LTE module */
+	{ USB_DEVICE(0x12d1, 0x15c3), .driver_info = USB_QUIRK_DISCONNECT_SUSPEND},
+	{ USB_DEVICE(0x12d1, 0x15bb), .driver_info = USB_QUIRK_DISCONNECT_SUSPEND},
+
 	/* SKYMEDI USB_DRIVE */
 	{ USB_DEVICE(0x1516, 0x8628), .driver_info = USB_QUIRK_RESET_RESUME },
 

--- a/include/linux/usb/quirks.h
+++ b/include/linux/usb/quirks.h
@@ -56,4 +56,9 @@
  */
 #define USB_QUIRK_LINEAR_FRAME_INTR_BINTERVAL	BIT(11)
 
+/* device need to be disconnect before suspend to prevent from unexpected
+ * wakeup.
+ */
+#define USB_QUIRK_DISCONNECT_SUSPEND		BIT(12)
+
 #endif /* __LINUX_USB_QUIRKS_H */


### PR DESCRIPTION
System will expectedly wakeup 3~4 seconds after suspend with this
device connected. It supports remote wakeup but been verified
disabled before usb port suspend. The only way to prevent this
is to unbind the port before system suspend.

This patch tries to introduce USB_QUIRK_DISCONNECT_SUSPEND quirk.
With this quirk set, the port connect to specific devices will
be disabled instead of suspend.

Signed-off-by: Chris Chiu <chiu@endlessm.com>

https://phabricator.endlessm.com/T18675