### PR TITLE
drm/nouveau/kms: pdate vblank state in response to modeset actions and remove call to  drm_crtc_vblank_off() during unload/suspend.

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_display.c
+++ b/drivers/gpu/drm/nouveau/nouveau_display.c
@@ -432,7 +432,6 @@ nouveau_display_fini(struct drm_device *dev, bool suspend)
 	struct nouveau_display *disp = nouveau_display(dev);
 	struct nouveau_drm *drm = nouveau_drm(dev);
 	struct drm_connector *connector;
-	struct drm_crtc *crtc;
 
 	if (!suspend) {
 		if (drm_drv_uses_atomic_modeset(dev))
@@ -440,10 +439,6 @@ nouveau_display_fini(struct drm_device *dev, bool suspend)
 		else
 			drm_crtc_force_disable_all(dev);
 	}
-
-	/* Make sure that drm and hw vblank irqs get properly disabled. */
-	drm_for_each_crtc(crtc, dev)
-		drm_crtc_vblank_off(crtc);
 
 	/* disable flip completion events */
 	nvif_notify_put(&drm->flip);

--- a/drivers/gpu/drm/nouveau/nv50_display.c
+++ b/drivers/gpu/drm/nouveau/nv50_display.c
@@ -3894,6 +3894,8 @@ nv50_disp_atomic_commit_tail(struct drm_atomic_state *state)
 
 		NV_ATOMIC(drm, "%s: clr %04x (set %04x)\n", crtc->name,
 			  asyh->clr.mask, asyh->set.mask);
+		if (crtc_state->active && !asyh->state.active)
+			drm_crtc_vblank_off(crtc);
 
 		if (asyh->clr.mask) {
 			nv50_head_flush_clr(head, asyh, atom->flush_disable);
@@ -3979,11 +3981,13 @@ nv50_disp_atomic_commit_tail(struct drm_atomic_state *state)
 			nv50_head_flush_set(head, asyh);
 			interlock_core = 1;
 		}
-	}
 
-	for_each_crtc_in_state(state, crtc, crtc_state, i) {
-		if (crtc->state->event)
-			drm_crtc_vblank_get(crtc);
+		if (asyh->state.active) {
+			if (!crtc_state->active)
+				drm_crtc_vblank_on(crtc);
+			if (asyh->state.event)
+				drm_crtc_vblank_get(crtc);
+		}
 	}
 
 	/* Update plane(s). */
@@ -4030,12 +4034,14 @@ nv50_disp_atomic_commit_tail(struct drm_atomic_state *state)
 		if (crtc->state->event) {
 			unsigned long flags;
 			/* Get correct count/ts if racing with vblank irq */
-			drm_accurate_vblank_count(crtc);
+			if (crtc->state->active)
+				drm_accurate_vblank_count(crtc);
 			spin_lock_irqsave(&crtc->dev->event_lock, flags);
 			drm_crtc_send_vblank_event(crtc, crtc->state->event);
 			spin_unlock_irqrestore(&crtc->dev->event_lock, flags);
 			crtc->state->event = NULL;
-			drm_crtc_vblank_put(crtc);
+			if (crtc->state->active)
+				drm_crtc_vblank_put(crtc);
 		}
 	}
 


### PR DESCRIPTION
update vblank state in response to modeset actions and remove call to 
drm_crtc_vblank_off() during unload/suspend. These on()/off() calls should
be done as a result of modesetting actions, and as we shut down all heads
already on unload/suspend, it's pointless to call off() again.

