### PR TITLE
ALSA: hda/realtek - Add support for ASUS GL503VM headset mic

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -4986,6 +4986,7 @@ enum {
 	ALC269VC_FIXUP_NL3_AUTOMUTE,
 	ALC286_FIXUP_ACER_AIO_MIC_NO_PRESENCE,
 	ALC294_FIXUP_ASUS_MIC,
+	ALC295_FIXUP_ASUS_MIC_NO_PRESENCE,
 };
 
 static const struct hda_fixup alc269_fixups[] = {
@@ -5805,6 +5806,15 @@ static const struct hda_fixup alc269_fixups[] = {
 		.chained = true,
 		.chain_id = ALC256_FIXUP_ASUS_HEADSET_MODE
 	},
+        [ALC295_FIXUP_ASUS_MIC_NO_PRESENCE] = {
+                .type = HDA_FIXUP_PINS,
+                .v.pins = (const struct hda_pintbl[]) {
+                        { 0x19, 0x01a1913c }, /* use as headset mic, without its own jack detect */
+                        { }
+                },
+                .chained = true,
+                .chain_id = ALC269_FIXUP_HEADSET_MODE
+        },
 };
 
 static const struct snd_pci_quirk alc269_fixup_tbl[] = {
@@ -6401,6 +6411,10 @@ static const struct snd_hda_pin_quirk alc269_pin_fixup_tbl[] = {
 		{0x12, 0x90a60130},
 		{0x17, 0x90170110},
 		{0x21, 0x02211020}),
+	SND_HDA_PIN_QUIRK(0x10ec0295, 0x1043, "ASUS", ALC295_FIXUP_ASUS_MIC_NO_PRESENCE,
+		{0x12, 0x90a60130},
+		{0x17, 0x90170110},
+		{0x21, 0x03211020}),
 	{}
 };
 


### PR DESCRIPTION
The ASUS laptop GL503VM with ALC295 can't detect the headset
microphone until we modify a pin definition.

https://phabricator.endlessm.com/T18650

Signed-off-by: Chris Chiu <chiu@endlessm.com>