### PR TITLE
sound/hda: Remove line out and fixup headset-mic on Acer TravelMate P648

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -5285,6 +5285,7 @@ enum {
 	ALC286_FIXUP_ACER_AIO_MIC_NO_PRESENCE,
 	ALC294_FIXUP_ASUS_MIC,
 	ALC295_FIXUP_ASUS_MIC_NO_PRESENCE,
+	ALC282_FIXUP_ACER_TRAVELMATE_PINS,
 };
 
 static const struct hda_fixup alc269_fixups[] = {
@@ -6123,6 +6124,16 @@ static const struct hda_fixup alc269_fixups[] = {
                 .chained = true,
                 .chain_id = ALC269_FIXUP_HEADSET_MODE
         },
+        [ALC282_FIXUP_ACER_TRAVELMATE_PINS] = {
+                .type = HDA_FIXUP_PINS,
+                .v.pins = (const struct hda_pintbl[]) {
+                        { 0x1b, 0x411111f0 },
+                        { 0x18, 0x01a1913c }, /* use as headset mic, without its own jack detect */
+                        { },
+                },
+                .chained = true,
+                .chain_id = ALC269_FIXUP_HEADSET_MODE
+        },
 };
 
 static const struct snd_pci_quirk alc269_fixup_tbl[] = {
@@ -6727,6 +6738,15 @@ static const struct snd_hda_pin_quirk alc269_pin_fixup_tbl[] = {
 		{0x12, 0x90a60130},
 		{0x17, 0x90170110},
 		{0x21, 0x03211020}),
+	SND_HDA_PIN_QUIRK(0x10ec0282, 0x1025, "Acer", ALC282_FIXUP_ACER_TRAVELMATE_PINS,
+		{0x12, 0x90a609c0},
+		{0x14, 0x90171110},
+		{0x18, 0x03a11830},
+		{0x19, 0x04a19831},
+		{0x1a, 0x0481303f},
+		{0x1b, 0x04211020},
+		{0x1d, 0x598301f0},
+		{0x21, 0x0321101f}),
 	{}
 };
 


### PR DESCRIPTION
A line out port given by BIOS doesn't have physical jack and the value
of 0x18 pin is also incorrect. Overriding with the correct values to
disable the line out pin and adds support for the headset microphone
which would not otherwise be visible in the system.

https://phabricator.endlessm.com/T18847

Signed-off-by: Chris Chiu <chiu@endlessm.com>