### PR TITLE
HID: usbhid: wake up system from usb mouse

### DIFF
--- a/drivers/hid/usbhid/hid-core.c
+++ b/drivers/hid/usbhid/hid-core.c
@@ -1160,6 +1160,15 @@ static int usbhid_start(struct hid_device *hid)
 		usbhid_set_leds(hid);
 		device_set_wakeup_enable(&dev->dev, 1);
 	}
+
+	/* Enable remote wakeup by default for all keyboard devices
+	 * supporting the boot protocol.
+	 */
+	if (interface->desc.bInterfaceSubClass == USB_INTERFACE_SUBCLASS_BOOT &&
+			interface->desc.bInterfaceProtocol ==
+				USB_INTERFACE_PROTOCOL_MOUSE) {
+		device_set_wakeup_enable(&dev->dev, 1);
+	}
 	return 0;
 
 fail:


### PR DESCRIPTION
It's been requested to wake up system from usb mouse also because
Windows also supports this. This commit follows the same way which
works on usb keyboard.

https://phabricator.endlessm.com/T19106

Signed-off-by: Chris Chiu <chiu@endlessm.com>