### PR TITLE
Partially revert "Disable nouveau on the Asus N552VW"

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1126,13 +1126,6 @@ err_free:
 
 static const struct dmi_system_id nouveau_modeset_0[] = {
 	{
-		.ident = "ASUSTeK COMPUTER INC. N552VW",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "N552VW"),
-		},
-	},
-	{
 		.ident = "Acer Aspire Z20-730",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),


### PR DESCRIPTION
This partially reverts commit 46a4ac01e92e81077eb9dd40cccbd4f9c4dd7c96,
only removing the Asus N552VW entry from the nouveau_modeset_0 array,
but keeping the quirk around for other platforms.

https://phabricator.endlessm.com/T11193