### PR TITLE
USB: serial: option: add support for MeiG LTE module SLM720

### DIFF
--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -95,6 +95,9 @@ static void option_instat_callback(struct urb *urb);
 
 #define NOVATELWIRELESS_VENDOR_ID		0x1410
 
+#define MEIG_VENDOR_ID				0x2DEE
+#define MEIG_PRODUCT_SLM720			0x4D07
+
 /* YISO PRODUCTS */
 
 #define YISO_VENDOR_ID				0x0EAB
@@ -2040,6 +2043,7 @@ static const struct usb_device_id option_ids[] = {
 	{ USB_DEVICE_AND_INTERFACE_INFO(WETELECOM_VENDOR_ID, WETELECOM_PRODUCT_6802, 0xff, 0xff, 0xff) },
 	{ USB_DEVICE_AND_INTERFACE_INFO(WETELECOM_VENDOR_ID, WETELECOM_PRODUCT_WMD300, 0xff, 0xff, 0xff) },
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x03f0, 0x421d, 0xff, 0xff, 0xff) }, /* HP lt2523 (Novatel E371) */
+	{ USB_DEVICE_AND_INTERFACE_INFO(MEIG_VENDOR_ID, MEIG_PRODUCT_SLM720, 0xff, 0x0, 0x0) },	/* MeiG 4G LTE M2M module SLM720 */
 	{ } /* Terminating entry */
 };
 MODULE_DEVICE_TABLE(usb, option_ids);


### PR DESCRIPTION
This commit adds support for MeiG LTE USB module SLM720 to option
driver.

T:  Bus=01 Lev=01 Prnt=01 Port=02 Cnt=02 Dev#=  3 Spd=480  MxCh= 0
D:  Ver= 2.00 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
P:  Vendor=2dee ProdID=4d07 Rev= 3.18
S:  Manufacturer=Android
S:  Product=Android
S:  SerialNumber=124346
C:* #Ifs= 6 Cfg#= 1 Atr=80 MxPwr=500mA
I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)
I:* If#= 1 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
I:* If#= 4 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
I:* If#= 5 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)

https://phabricator.endlessm.com/T20061

Signed-off-by: Chris Chiu <chiu@endlessm.com>