### PR TITLE
tpm: fix suspend failure on Acer Veriton X4110G

### DIFF
--- a/drivers/char/tpm/tpm-interface.c
+++ b/drivers/char/tpm/tpm-interface.c
@@ -953,6 +953,11 @@ int tpm_do_selftest(struct tpm_chip *chip)
 	loops = jiffies_to_msecs(duration) / delay_msec;
 
 	rc = tpm_continue_selftest(chip);
+	if (rc == TPM_ERR_INVALID_POSTINIT) {
+		chip->flags |= TPM_CHIP_FLAG_ALWAYS_POWERED;
+		if (tpm_startup(chip))
+			return rc;
+	}
 	/* This may fail if there was no TPM driver during a suspend/resume
 	 * cycle; some may return 10 (BAD_ORDINAL), others 28 (FAILEDSELFTEST)
 	 */


### PR DESCRIPTION
The TPM on Acer Veriton X4110G shows the following message in the
first resume.
  tpm tpm0: A TPM error(38) occured continue selftest
And error(38) is TPM_ERR_INVALID_POSTINIT which means the TPM is
not in the correct state. Then the following suspend will always
fail with the following messages.
  tpm tpm0: Error (38) sending savestate before suspend
  PM: Device 00:0b failed to suspend: error 38

This commit fix the TPM state by performing tpm_startup again and
prevent same error in tpm_pm_suspend.

https://phabricator.endlessm.com/T20438

Signed-off-by: Chris Chiu <chiu@endlessm.com>