### PR TITLE
acer-wireless: send an EV_SYN/SYN_REPORT between state changes

### DIFF
--- a/drivers/platform/x86/acer-wireless.c
+++ b/drivers/platform/x86/acer-wireless.c
@@ -37,6 +37,7 @@ static void acer_wireless_notify(struct acpi_device *adev, u32 event)
 		return;
 	}
 	input_report_key(data->idev, KEY_RFKILL, 1);
+	input_sync(data->idev);
 	input_report_key(data->idev, KEY_RFKILL, 0);
 	input_sync(data->idev);
 }


### PR DESCRIPTION
Sending the switch state change twice within the same frame is invalid
evdev protocol and only works if the client handles keys immediately as
well. Processing events immediately is incorrect, it forces a fake
order of events that does not exist on the device.

Recent versions of libinput changed to only process the device state and
SYN_REPORT time, so now the key event is lost.

Same fix as bff5bf9db1c94 "platform/x86: asus-wireless: send an
EV_SYN/SYN_REPORT between state changes"

https://phabricator.endlessm.com/T20508

Signed-off-by: Daniel Drake <drake@endlessm.com>