### PR TITLE
Revert "ideapad_laptop: Makes radio ON/OFF key emit KEY_RFKILL"

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -673,7 +673,7 @@ static const struct key_entry ideapad_keymap[] = {
 	{ KE_KEY, 7,  { KEY_CAMERA } },
 	{ KE_KEY, 8,  { KEY_MICMUTE } },
 	{ KE_KEY, 11, { KEY_F16 } },
-	{ KE_KEY, 13, { KEY_RFKILL } },
+	{ KE_KEY, 13, { KEY_WLAN } },
 	{ KE_KEY, 16, { KEY_PROG1 } },
 	{ KE_KEY, 17, { KEY_PROG2 } },
 	{ KE_KEY, 64, { KEY_PROG3 } },


### PR DESCRIPTION
This reverts commit 7a2cc124474eafd78b7cf785d0d4d76b69e47fbc.

Userspace is now treating KEY_WLAN as airplane-mode, so we can drop this
change.

https://phabricator.endlessm.com/T20508