### PR TITLE
drm/nouveau: Disable runtime pm on more Asus laptops

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1170,6 +1170,27 @@ static const struct dmi_system_id nouveau_rpm_0[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "X550VXK"),
 		},
 	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. X542UQ",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X542UQ"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. P1440UF",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "P1440UF"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. P2440UF",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "P2440UF"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
The Asus X542UQ/P1440UF/P2440UF laptops have two video cards
(Intel+NVIDIA GM108). There is a problem with the interaction
between runtime pm and suspend/resume which leads to the machine
hanging on shutdown. Add these to dmi quirk table which disables
runpm.

phabricator: https://phabricator.endlessm.com/T20646