### PR TITLE
drm/nouveau: Disable runtime pm on the Asus X555UQ

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -587,6 +587,17 @@ static const struct dmi_system_id nouveau_rpm_blacklist[] = {
 	{ }
 };
 
+static const struct dmi_system_id nouveau_accel_blacklist[] = {
+	{
+		.ident = "ASUS X555UQ",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X555UQ"),
+		},
+	},
+	{ }
+};
+
 static int
 nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 {
@@ -643,6 +654,11 @@ nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 	    dmi_check_system(dmi_acer_laptop)) {
 		NV_INFO(drm, "Acer laptop with chipset 0x%X, disabling acceleration\n",
 			drm->client.device.info.chipset);
+		nouveau_noaccel = 1;
+	}
+
+	if (dmi_check_system(nouveau_accel_blacklist)) {
+		NV_INFO(drm, "Acceleration is blacklisted on this machine\n");
 		nouveau_noaccel = 1;
 	}
 

--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -562,6 +562,31 @@ static const struct dmi_system_id dmi_acer_laptop[] = {
 	{ }
 };
 
+static const struct dmi_system_id nouveau_rpm_blacklist[] = {
+	{
+		.ident = "ASUSTeK COMPUTER INC. GL552VXK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "GL552VXK"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. K401UQK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "K401UQK"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. X550VXK",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "X550VXK"),
+		},
+	},
+	{ }
+};
+
 static int
 nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 {
@@ -605,6 +630,11 @@ nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 	    dmi_check_system(dmi_asus_laptop)) {
 		NV_INFO(drm, "Asus laptop with chipset 0x%X, disabling runtime PM\n",
 			drm->client.device.info.chipset);
+		nouveau_runtime_pm = 0;
+	}
+
+	if (dmi_check_system(nouveau_rpm_blacklist)) {
+		NV_INFO(drm, "Runtime PM is blacklisted on this machine\n");
 		nouveau_runtime_pm = 0;
 	}
 
@@ -1257,31 +1287,6 @@ static const struct dmi_system_id nouveau_disable[] = {
 	{ }
 };
 
-static const struct dmi_system_id nouveau_rpm_blacklist[] = {
-	{
-		.ident = "ASUSTeK COMPUTER INC. GL552VXK",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "GL552VXK"),
-		},
-	},
-	{
-		.ident = "ASUSTeK COMPUTER INC. K401UQK",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "K401UQK"),
-		},
-	},
-	{
-		.ident = "ASUSTeK COMPUTER INC. X550VXK",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "X550VXK"),
-		},
-	},
-	{ }
-};
-
 static int __init
 nouveau_drm_init(void)
 {
@@ -1290,9 +1295,6 @@ nouveau_drm_init(void)
 
 	if (dmi_check_system(nouveau_disable))
 		nouveau_modeset = 0;
-
-	if (dmi_check_system(nouveau_rpm_blacklist))
-		nouveau_runtime_pm = 0;
 
 	nouveau_display_options();
 

--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -1309,10 +1309,10 @@ nouveau_drm_init(void)
 	driver_pci = driver_stub;
 	driver_platform = driver_stub;
 
+	nouveau_display_options();
+
 	if (dmi_check_system(nouveau_disable))
 		nouveau_modeset = 0;
-
-	nouveau_display_options();
 
 	if (nouveau_modeset == -1) {
 		if (vgacon_text_force())


### PR DESCRIPTION
The Asus X555UQ has two video cards (Intel+NVIDIA). There is a problem
with the interaction between runtime pm and suspend/resume which leads
to the machine hanging on shutdown.

https://phabricator.endlessm.com/T20281