### PR TITLE
Revert "Bluetooth: btusb: driver to enable the usb-wakeup feature"

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -1091,10 +1091,6 @@ static int btusb_open(struct hci_dev *hdev)
 	}
 
 	data->intf->needs_remote_wakeup = 1;
-	/* device specific wakeup source enabled and required for USB
-	 * remote wakeup while host is suspended
-	 */
-	device_wakeup_enable(&data->udev->dev);
 
 	if (test_and_set_bit(BTUSB_INTR_RUNNING, &data->flags))
 		goto done;
@@ -1158,7 +1154,6 @@ static int btusb_close(struct hci_dev *hdev)
 		goto failed;
 
 	data->intf->needs_remote_wakeup = 0;
-	device_wakeup_disable(&data->udev->dev);
 	usb_autopm_put_interface(data->intf);
 
 failed:


### PR DESCRIPTION
This reverts commit a0085f2510e8976614ad8f766b209448b385492f.

This may cause spurious wake-ups or prevent the system from entering
suspend at all.

https://patchwork.kernel.org/patch/10121401/
https://phabricator.endlessm.com/T20764