### PR TITLE
nouveau/gm108: Enable noaccel quirk for Asus Notebooks

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -615,7 +615,7 @@ nouveau_drm_load(struct drm_device *dev, unsigned long flags)
 
 	if (drm->client.device.info.chipset == 0x118 &&
 	    dmi_check_system(gm108_runpm_blacklist))
-		nouveau_runtime_pm = 0;
+		nouveau_noaccel = 1;
 
 	if (drm->client.device.info.chipset == 0x137 &&
 	    dmi_check_system(gp107_accel_blacklist))


### PR DESCRIPTION
The Asus X542UF/X542UQ, P1440UF/P2440UF and more models with NVIDIA
940MX, MX110/MX130 requires passing 'nouveau.noaccel=1' at boot to
have it working correctly and avoid boot or shutdown failure. If
only disable runtime pm, it stills incurs the side effect which is
the shutdown/reboot takes ~3 minutes to complete.

This commit turns on noaccel for all Asus Notebooks with the display
chip NV GM108.

It has to be reverted once if there's a upstream fix.

https://phabricator.endlessm.com/T20991

Signed-off-by: Chris Chiu <chiu@endlessm.com>