### PR TITLE
nouveau_drm: ASUS FX570UD can't resume with nouveau

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -570,6 +570,13 @@ static const struct dmi_system_id gp107_accel_blacklist[] = {
 			DMI_MATCH(DMI_CHASSIS_TYPE, "10"), /* Notebook */
                 },
         },
+	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS Gaming FX570UD",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "ASUS Gaming FX570UD"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
The NV GTX 1050M of FX570UD cannot resume back from suspend with the
normal display when use the nouveau without setting the module parameter
noaccel.

Set the nouveau's module parameter noaccel to 1 can fix this problem.

https://phabricator.endlessm.com/T21413