### PR TITLE
rt5645: add internal microphone support and fix jack detection

### DIFF
--- a/sound/soc/codecs/rt5645.c
+++ b/sound/soc/codecs/rt5645.c
@@ -3704,6 +3704,23 @@ static const struct dmi_system_id dmi_platform_minix_z83_4[] = {
 	{ }
 };
 
+static const struct rt5645_platform_data shuttle_xo0ct12_platform_data = {
+	.dmic1_data_pin = RT5645_DMIC_DATA_IN2N,
+	.dmic2_data_pin = RT5645_DMIC2_DISABLE,
+	.jd_mode = 3,
+};
+
+static const struct dmi_system_id dmi_platform_shuttle_xo0ct12[] = {
+	{
+		.ident = "Shuttle XO0CT12",
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Shuttle"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "XO0CT12"),
+		},
+	},
+	{ }
+};
+
 static bool rt5645_check_dp(struct device *dev)
 {
 	if (device_property_present(dev, "realtek,in2-differential") ||
@@ -3773,6 +3790,8 @@ static int rt5645_i2c_probe(struct i2c_client *i2c,
 		rt5645->pdata = general_platform_data2;
 	else if (dmi_check_system(dmi_platform_minix_z83_4))
 		rt5645->pdata = minix_z83_4_platform_data;
+	else if (dmi_check_system(dmi_platform_shuttle_xo0ct12))
+		rt5645->pdata = shuttle_xo0ct12_platform_data;
 
 	if (quirk != -1) {
 		rt5645->pdata.in2_diff = QUIRK_IN2_DIFF(quirk);


### PR DESCRIPTION
The internal mic of Shuttle XO0CT12 is on DMIC1/IN2N. It also
requires jd_mode=3 to make the jack detection work.

https://phabricator.endlessm.com/T20479