### PR TITLE
T22136

### DIFF
--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -493,8 +493,6 @@ static const struct key_entry asus_nb_wmi_keymap[] = {
 	{ KE_KEY, 0xA6, { KEY_SWITCHVIDEOMODE } }, /* SDSP CRT + TV + HDMI */
 	{ KE_KEY, 0xA7, { KEY_SWITCHVIDEOMODE } }, /* SDSP LCD + CRT + TV + HDMI */
 	{ KE_KEY, 0xB5, { KEY_CALC } },
-	{ KE_KEY, 0xC4, { KEY_KBDILLUMUP } },
-	{ KE_KEY, 0xC5, { KEY_KBDILLUMDOWN } },
 	{ KE_IGNORE, 0xC6, },  /* Ambient Light Sensor notification */
 	{ KE_END, 0},
 };

--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -496,7 +496,6 @@ static const struct key_entry asus_nb_wmi_keymap[] = {
 	{ KE_KEY, 0xC4, { KEY_KBDILLUMUP } },
 	{ KE_KEY, 0xC5, { KEY_KBDILLUMDOWN } },
 	{ KE_IGNORE, 0xC6, },  /* Ambient Light Sensor notification */
-	{ KE_KEY, 0xC7, { KEY_KBDILLUMTOGGLE } },
 	{ KE_END, 0},
 };
 

--- a/drivers/platform/x86/asus-wmi.c
+++ b/drivers/platform/x86/asus-wmi.c
@@ -67,6 +67,7 @@ MODULE_LICENSE("GPL");
 #define NOTIFY_BRNDOWN_MAX		0x2e
 #define NOTIFY_KBD_BRTUP		0xc4
 #define NOTIFY_KBD_BRTDWN		0xc5
+#define NOTIFY_KBD_BRTTOGGLE		0xc7
 
 /* WMI Methods */
 #define ASUS_WMI_METHODID_SPEC	        0x43455053 /* BIOS SPECification */
@@ -1704,7 +1705,9 @@ static int is_display_toggle(int code)
 
 static int is_kbd_led_event(int code)
 {
-	if (code == NOTIFY_KBD_BRTUP || code == NOTIFY_KBD_BRTDWN)
+	if (code == NOTIFY_KBD_BRTUP ||
+	    code ==  NOTIFY_KBD_BRTDWN ||
+	    code ==  NOTIFY_KBD_BRTTOGGLE)
 		return 1;
 	return 0;
 }
@@ -1755,7 +1758,10 @@ static void asus_wmi_notify(u32 value, void *context)
 	}
 
 	if (is_kbd_led_event(code)) {
-		if (code == NOTIFY_KBD_BRTDWN)
+		if (code == NOTIFY_KBD_BRTTOGGLE &&
+		    asus->kbd_led_wk == asus->kbd_led.max_brightness)
+			kbd_led_set(&asus->kbd_led, 0);
+		else if (code == NOTIFY_KBD_BRTDWN)
 			kbd_led_set(&asus->kbd_led, asus->kbd_led_wk - 1);
 		else
 			kbd_led_set(&asus->kbd_led, asus->kbd_led_wk + 1);

--- a/drivers/platform/x86/asus-wmi.c
+++ b/drivers/platform/x86/asus-wmi.c
@@ -67,7 +67,6 @@ MODULE_LICENSE("GPL");
 #define NOTIFY_BRNDOWN_MAX		0x2e
 #define NOTIFY_KBD_BRTUP		0xc4
 #define NOTIFY_KBD_BRTDWN		0xc5
-#define NOTIFY_KBD_BRTTOGGLE		0xc7
 
 /* WMI Methods */
 #define ASUS_WMI_METHODID_SPEC	        0x43455053 /* BIOS SPECification */
@@ -1744,13 +1743,6 @@ static void asus_wmi_notify(u32 value, void *context)
 			asus_wmi_backlight_notify(asus, orig_code);
 			goto exit;
 		}
-	}
-
-	if (code == NOTIFY_KBD_BRTTOGGLE) {
-		if (asus->kbd_led_wk < asus->kbd_led.max_brightness)
-			code = NOTIFY_KBD_BRTUP;
-		else
-			code = NOTIFY_KBD_BRTTOGGLE;
 	}
 
 	if (is_display_toggle(code) &&


### PR DESCRIPTION
platform/x86: asus-wmi: Call new led hw_changed API on kbd brightness change

Make asus-wmi notify on hotkey kbd brightness changes, listen for
these brightness down/up/toggle events corresponds to Fn+F3/F4/F7
and call led_classdev_notify_brightness_hw_changed.

This will allow userspace to monitor (poll) for brightness changes
on the LED caused by the hotkey. Note that brightness toggle hotkey
would incremet the level of brightness if the max brightness > 1,
then toggle (off) the LED when it already reached the max level.

https://phabricator.endlessm.com/T22136

Signed-off-by: Chris Chiu <chiu@endlessm.com>