### PR TITLE
nouveau_drm: ASUS X560UD can't resume with nouveau

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -664,6 +664,13 @@ static const struct dmi_system_id accel_blacklist[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "ASUS Gaming FX570UD"),
 		},
 	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS X560UD",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X560UD"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
The NV GTX 1050M of X560UD cannot resume back from suspend with the
normal display when use the nouveau without setting the module parameter
noaccel.

Set the nouveau's module parameter noaccel to 1 can fix this problem.

https://phabricator.endlessm.com/T22813

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>