### PR TITLE
nouveau_drm: Acer Predator Orion 5-100 can't resume with nouveau

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -593,6 +593,13 @@ static const struct dmi_system_id runpm_blacklist[] = {
 		},
 	},
 	{
+		.ident = "Acer Predator Orion 5-100",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Predator Orion 5-100"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. GL552VXK",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
@@ -655,6 +662,13 @@ static const struct dmi_system_id accel_blacklist[] = {
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "Nitro N50-600"),
+		},
+	},
+	{
+		.ident = "Acer Predator Orion 5-100",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Predator Orion 5-100"),
 		},
 	},
 	{


### PR DESCRIPTION
The NV GTX 1050 Ti of Predator Orion 5-100 cannot resume back from
suspend with the normal display when use the nouveau without setting the
module parameters runpm and noaccel.

Set the nouveau's module parameters runpm to 0 and noaccel to 1 can fix
this problem.

https://phabricator.endlessm.com/T21605

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>