### PR TITLE
nouveau_drm: disable runpm and accel on ASUS X530UN and X705FD

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -614,10 +614,24 @@ static const struct dmi_system_id runpm_blacklist[] = {
 		},
 	},
 	{
+		.ident = "ASUSTeK COMPUTER INC. X530UN",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X530UN"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. X550VXK",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
 			DMI_MATCH(DMI_PRODUCT_NAME, "X550VXK"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. X705FD",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X705FD"),
 		},
 	},
 	{ }
@@ -679,10 +693,24 @@ static const struct dmi_system_id accel_blacklist[] = {
 		},
 	},
 	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS X530UN",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X530UN"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. ASUS X560UD",
 		.matches = {
 			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
 			DMI_MATCH(DMI_BOARD_NAME, "X560UD"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS X705FD",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X705FD"),
 		},
 	},
 	{ }


### PR DESCRIPTION
The NV GTX 1050M of X705FD and MX150 on X530UN cannot resume back
from suspend with the normal display.

Setting the module parameters noaccel=1 and runpm=0 fix it.

https://phabricator.endlessm.com/T22813
https://phabricator.endlessm.com/T23033

Signed-off-by: Chris Chiu <chiu@endlessm.com>