### PR TITLE
r8822be: Disable ASPM of r8822be on ASUS X530UN

### DIFF
--- a/drivers/staging/rtlwifi/rtl8822be/sw.c
+++ b/drivers/staging/rtlwifi/rtl8822be/sw.c
@@ -40,6 +40,18 @@
 #include "../phydm/rtl_phydm.h"
 #include <linux/vmalloc.h>
 #include <linux/module.h>
+#include <linux/dmi.h>
+
+static const struct dmi_system_id aspm_zero_quirk[] = {
+	{
+		.ident = "ASUS X530UN",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X530UN"),
+		},
+	},
+	{ }
+};
 
 static void rtl8822be_init_aspm_vars(struct ieee80211_hw *hw)
 {
@@ -84,6 +96,8 @@ static void rtl8822be_init_aspm_vars(struct ieee80211_hw *hw)
 	 * 1 - Support ASPM,
 	 * 2 - According to chipset.
 	 */
+	if (dmi_check_system(aspm_zero_quirk))
+		rtlpriv->cfg->mod_params->aspm_support = 0;
 	rtlpci->const_support_pciaspm = rtlpriv->cfg->mod_params->aspm_support;
 }
 


### PR DESCRIPTION
The laptop ASUS X530UN's rtl8822be cannnot find any WiFi access point
with enabled ASPM.

[    8.591333] r8822be: module is from the staging directory, the
quality is unknown, you have been warned.
[    8.593122] r8822be 0000:02:00.0: enabling device (0000 -> 0003)
[    8.669163] r8822be: Using firmware rtlwifi/rtl8822befw.bin
[    9.289939] r8822be: rtlwifi: wireless switch is on
[   10.056426] r8822be 0000:02:00.0 wlp2s0: renamed from wlan0
...
[   11.952534] r8822be: halmac_init_hal failed
[   11.955933] r8822be: halmac_init_hal failed
[   11.956227] r8822be: halmac_init_hal failed
[   22.007942] r8822be: halmac_init_hal failed

Disabling ASPM for rtl8822be on ASUS X530UN can fix this bug.

https://phabricator.endlessm.com/T23038

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>