### PR TITLE
Import linux-meta packages

### DIFF
--- a/debian.master/control.d/flavour-control.stub
+++ b/debian.master/control.d/flavour-control.stub
@@ -45,6 +45,44 @@ Description: Linux kernel image for version PKGVER on DESC
  the linux-FLAVOUR meta-package, which will ensure that upgrades work
  correctly, and that supporting packages are also installed.
 
+Package: linux-image-FLAVOUR
+Architecture: i386 amd64 armhf arm64 powerpc ppc64el s390x
+Section: kernel
+Depends: ${misc:Depends}, linux-image-PKGVER-ABINUM-FLAVOUR, linux-modules-extra-PKGVER-ABINUM-FLAVOUR [i386 amd64 arm64 powerpc ppc64el s390x], linux-firmware
+Recommends: thermald [i386 amd64]
+Conflicts: linux-signed-image-FLAVOUR
+Description: Generic Linux kernel image
+ This package will always depend on the latest generic kernel image
+ available.
+
+Package: linux-signed-image-FLAVOUR
+Architecture: amd64
+Section: kernel
+Depends: ${misc:Depends}, linux-signed-image-PKGVER-ABINUM-FLAVOUR, linux-modules-extra-PKGVER-ABINUM-FLAVOUR, linux-firmware
+Recommends: thermald [i386 amd64]
+Conflicts: linux-image-FLAVOUR
+Description: Signed Generic Linux kernel image
+ This package will always depend on the latest generic kernel image
+ available.  Signed with the Ubuntu EFI key.
+
+Package: linux-signed-FLAVOUR
+Architecture: amd64
+Section: kernel
+Depends: ${misc:Depends}, linux-signed-image-FLAVOUR (= ${binary:Version}), linux-headers-FLAVOUR (= ${binary:Version})
+Conflicts: linux-FLAVOUR
+Description: Complete Signed Generic Linux kernel and headers
+ This package will always depend on the latest complete generic Linux kernel
+ and headers.  Signed with the Ubuntu EFI key.
+
+Package: linux-FLAVOUR
+Architecture: i386 amd64 armhf arm64 powerpc ppc64el s390x
+Section: kernel
+Depends: ${misc:Depends}, linux-image-FLAVOUR (= ${binary:Version}), linux-headers-FLAVOUR (= ${binary:Version})
+Conflicts: linux-signed-FLAVOUR
+Description: Complete Generic Linux kernel and headers
+ This package will always depend on the latest complete generic Linux kernel
+ and headers.
+
 Package: linux-modules-PKGVER-ABINUM-FLAVOUR
 Build-Profiles: <!stage1>
 Architecture: ARCH
@@ -100,6 +138,14 @@ Description: Linux kernel headers for version PKGVER on DESC
  This is for sites that want the latest kernel headers.  Please read
  /usr/share/doc/linux-headers-PKGVER-ABINUM/debian.README.gz for details.
 
+Package: linux-headers-FLAVOUR
+Architecture: i386 amd64 armhf arm64 powerpc ppc64el s390x
+Section: kernel
+Depends: ${misc:Depends}, linux-headers-PKGVER-ABINUM-FLAVOUR
+Description: Generic Linux kernel headers
+ This package will always depend on the latest generic kernel headers
+ available.
+
 Package: linux-image=SIGN-ME-PKG=-PKGVER-ABINUM-FLAVOUR-dbgsym
 Build-Profiles: <!stage1>
 Architecture: ARCH
@@ -128,6 +174,15 @@ Description: Linux kernel version specific tools for version PKGVER-ABINUM
  version locked tools (such as perf and x86_energy_perf_policy) for
  version PKGVER-ABINUM on
  =HUMAN=.
+
+Package: linux-tools-FLAVOUR
+Architecture: i386 amd64 armhf arm64 powerpc ppc64el s390x
+Section: kernel
+Provides: linux-tools
+Depends: ${misc:Depends}, linux-tools-PKGVER-ABINUM-FLAVOUR
+Description: Generic Linux kernel tools
+ This package will always depend on the latest generic kernel tools
+ available.
 
 Package: linux-cloud-tools-PKGVER-ABINUM-FLAVOUR
 Build-Profiles: <!stage1>

--- a/debian.master/control.stub.in
+++ b/debian.master/control.stub.in
@@ -70,6 +70,13 @@ Description: Linux kernel source for version PKGVER with Ubuntu patches
  you do not want this package. Install the appropriate linux-headers
  package instead.
 
+Package: linux-source
+Architecture: all
+Depends: ${misc:Depends}, linux-source-PKGVER
+Description: Linux kernel source with Ubuntu patches
+ This package will always depend on the latest Linux kernel source code
+ available. The Ubuntu patches have been applied.
+
 Package: SRCPKGNAME-doc
 Build-Profiles: <!stage1>
 Architecture: all

--- a/debian/rules.d/2-binary-arch.mk
+++ b/debian/rules.d/2-binary-arch.mk
@@ -456,13 +456,19 @@ endif
 endif
 
 binary-%: pkgimg = $(bin_pkg_name)-$*
+binary-%: metapkgimg = linux-image-$*
+binary-%: metapkgsignedimg = linux-signed-image-$*
+binary-%: metapkgsigned = linux-signed-$*
+binary-%: metapkg = linux-$*
 binary-%: pkgimg_mods = $(mods_pkg_name)-$*
 binary-%: pkgimg_ex = $(mods_extra_pkg_name)-$*
 binary-%: pkgdir_ex = $(CURDIR)/debian/$(extra_pkg_name)-$*
 binary-%: pkghdr = $(hdrs_pkg_name)-$*
+binary-%: metapkghdr = linux-headers-$*
 binary-%: dbgpkg = $(bin_pkg_name)-$*-dbgsym
 binary-%: dbgpkgdir = $(CURDIR)/debian/$(bin_pkg_name)-$*-dbgsym
 binary-%: pkgtools = $(tools_flavour_pkg_name)-$*
+binary-%: metapkgtools = linux-tools-$*
 binary-%: pkgcloud = $(cloud_flavour_pkg_name)-$*
 binary-%: rprovides = $(if $(filter true,$(call custom_override,do_zfs,$*)),$(comma) spl-modules$(comma) spl-dkms$(comma) zfs-modules$(comma) zfs-dkms)
 binary-%: target_flavour = $*
@@ -480,6 +486,42 @@ binary-%: install-%
 	$(lockme) dh_gencontrol -p$(pkgimg) -- -Vlinux:rprovides='$(rprovides)'
 	dh_md5sums -p$(pkgimg)
 	dh_builddeb -p$(pkgimg)
+	dh_installdirs -p$(metapkgimg)
+	dh_installdocs -p$(metapkgimg)
+	dh_installchangelogs -p$(metapkgimg)
+	dh_compress -p$(metapkgimg)
+	dh_fixperms -p$(metapkgimg)
+	dh_installdeb -p$(metapkgimg)
+	$(lockme) dh_gencontrol -p$(metapkgimg)
+	dh_md5sums -p$(metapkgimg)
+	dh_builddeb -p$(metapkgimg)
+	dh_installdirs -p$(metapkgsignedimg)
+	dh_installdocs -p$(metapkgsignedimg)
+	dh_installchangelogs -p$(metapkgsignedimg)
+	dh_compress -p$(metapkgsignedimg)
+	dh_fixperms -p$(metapkgsignedimg)
+	dh_installdeb -p$(metapkgsignedimg)
+	$(lockme) dh_gencontrol -p$(metapkgsignedimg)
+	dh_md5sums -p$(metapkgsignedimg)
+	dh_builddeb -p$(metapkgsignedimg)
+	dh_installdirs -p$(metapkgsigned)
+	dh_installdocs -p$(metapkgsigned)
+	dh_installchangelogs -p$(metapkgsigned)
+	dh_compress -p$(metapkgsigned)
+	dh_fixperms -p$(metapkgsigned)
+	dh_installdeb -p$(metapkgsigned)
+	$(lockme) dh_gencontrol -p$(metapkgsigned)
+	dh_md5sums -p$(metapkgsigned)
+	dh_builddeb -p$(metapkgsigned)
+	dh_installdirs -p$(metapkg)
+	dh_installdocs -p$(metapkg)
+	dh_installchangelogs -p$(metapkg)
+	dh_compress -p$(metapkg)
+	dh_fixperms -p$(metapkg)
+	dh_installdeb -p$(metapkg)
+	$(lockme) dh_gencontrol -p$(metapkg)
+	dh_md5sums -p$(metapkg)
+	dh_builddeb -p$(metapkg)
 
 	dh_installchangelogs -p$(pkgimg_mods)
 	dh_installdocs -p$(pkgimg_mods)
@@ -523,6 +565,15 @@ endif
 	$(lockme) dh_gencontrol -p$(pkghdr)
 	dh_md5sums -p$(pkghdr)
 	dh_builddeb -p$(pkghdr)
+	dh_installdirs -p$(metapkghdr)
+	dh_installdocs -p$(metapkghdr)
+	dh_installchangelogs -p$(metapkghdr)
+	dh_compress -p$(metapkghdr)
+	dh_fixperms -p$(metapkghdr)
+	dh_installdeb -p$(metapkghdr)
+	$(lockme) dh_gencontrol -p$(metapkghdr)
+	dh_md5sums -p$(metapkghdr)
+	dh_builddeb -p$(metapkghdr)
 
 ifneq ($(skipsub),true)
 	@set -e; for sub in $($(*)_sub); do		\
@@ -581,6 +632,15 @@ ifeq ($(do_linux_tools),true)
 	$(lockme) dh_gencontrol -p$(pkgtools)
 	dh_md5sums -p$(pkgtools)
 	dh_builddeb -p$(pkgtools)
+	dh_installdirs -p$(metapkgtools)
+	dh_installdocs -p$(metapkgtools)
+	dh_installchangelogs -p$(metapkgtools)
+	dh_compress -p$(metapkgtools)
+	dh_fixperms -p$(metapkgtools)
+	dh_installdeb -p$(metapkgtools)
+	$(lockme) dh_gencontrol -p$(metapkgtools)
+	dh_md5sums -p$(metapkgtools)
+	dh_builddeb -p$(metapkgtools)
 endif
 ifeq ($(do_cloud_tools),true)
 	dh_installchangelogs -p$(pkgcloud)


### PR DESCRIPTION
Import meta packages from linux-meta that map to the versioned packages
built by the linux source package. This way we can get rid of linux-meta
and don't need to bump its ABI version on every rebase.

https://phabricator.endlessm.com/T16504