### PR TITLE
nouveau_drm: Disable runpm and accel on Acer Nitro N50-100

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -555,6 +555,13 @@ static const struct dmi_system_id nouveau_blacklist[] = {
 
 static const struct dmi_system_id runpm_blacklist[] = {
 	{
+		.ident = "Acer Nitro N50-100",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Nitro N50-100"),
+		},
+	},
+	{
 		.ident = "Acer Nitro N50-600",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
@@ -640,6 +647,13 @@ static const struct dmi_system_id gp107_accel_blacklist[] = {
 };
 
 static const struct dmi_system_id accel_blacklist[] = {
+	{
+		.ident = "Acer Nitro N50-100",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Nitro N50-100"),
+		},
+	},
 	{
 		.ident = "Acer Nitro N50-600",
 		.matches = {


### PR DESCRIPTION
The NV GTX 1050Ti of Acer Nitro N50-100 cannot resume back from suspend
with the normal display.

Setting the module parameters noaccel=1 and runpm=0 fix it.

https://phabricator.endlessm.com/T23367

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>