### PR TITLE
USB: Force disconnect Intel bluetooth adapter during suspend

### DIFF
--- a/drivers/usb/core/quirks.c
+++ b/drivers/usb/core/quirks.c
@@ -405,6 +405,10 @@ static const struct usb_device_id usb_quirk_list[] = {
 	/* INTEL VALUE SSD */
 	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
 
+	/* INTEL bluetooth adapter */
+	{ USB_DEVICE(0x8087, 0x0aaa), .driver_info =
+			USB_QUIRK_DISCONNECT_SUSPEND},
+
 	{ }  /* terminating entry must be last */
 };
 


### PR DESCRIPTION
After going into S3/s2idle suspend, sometimes there will be a GPE
event from Embedded Controller which indicates a wake up signal from
the USB controller. Then the system will wake up unexpectedly. After
removing the btusb driver or just turn off bluetooth, it goses to
suspend just fine. However, there's neither paired nor connected
devices which could possibly wake up the system when it reproduces.

Quirks like USB_QUIRK_RESET_RESUME, USB_QUIRK_RESET, USB_QUIRK_NO_LPM,
USB_QUIRK_IGNORE_REMOTE_WAKEUP do no help.

Apply USB_QUIRK_DISCONNECT_SUSPEND to avoid the issue until the root
cause found and addressed.

https://phabricator.endlessm.com/T23395

Signed-off-by: Chris Chiu <chiu@endlessm.com>