### PR TITLE
nouveau_drm: Disable accel on ASUS UX533FD

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -676,6 +676,13 @@ static const struct dmi_system_id accel_blacklist[] = {
 		},
 	},
 	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS UX533FD",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "UX533FD"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. ASUS X530UN",
 		.matches = {
 			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),


### PR DESCRIPTION
The NV GTX 1050M of ASUS UX533FD cannot resume back from suspend with
the normal display.

Using nouveau with parameter noaccel=1 fixes it.

https://phabricator.endlessm.com/T23227
https://phabricator.endlessm.com/T23291

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>