### PR TITLE
nouveau_drm: Disable accel on ASUS X570ZD

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -712,6 +712,13 @@ static const struct dmi_system_id accel_blacklist[] = {
 		},
 	},
 	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS X570ZD",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "X570ZD"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. ASUS X705FD",
 		.matches = {
 			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),


### PR DESCRIPTION
The NV GTX 1050M of ASUS X570ZD cannot resume back from suspend with
the normal display.

Using nouveau with parameter noaccel=1 fixes it.

https://phabricator.endlessm.com/T22624

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>