### PR TITLE
nouveau_drm: Disable accel/runpm on ASUS UX433FN

### DIFF
--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -605,6 +605,13 @@ static const struct dmi_system_id runpm_blacklist[] = {
 		},
 	},
 	{
+		.ident = "ASUSTeK COMPUTER INC. UX433FN",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "UX433FN"),
+		},
+	},
+	{
 		.ident = "ASUSTeK COMPUTER INC. X530UN",
 		.matches = {
 			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
@@ -688,6 +695,13 @@ static const struct dmi_system_id accel_blacklist[] = {
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
 			DMI_MATCH(DMI_PRODUCT_NAME, "ASUS Gaming FX570UD"),
+		},
+	},
+	{
+		.ident = "ASUSTeK COMPUTER INC. ASUS UX433FN",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_BOARD_NAME, "UX433FN"),
 		},
 	},
 	{


### PR DESCRIPTION
The NV MX150 (GP108) on UX433FN fails to resume from suspend and
also hangs on shutdown.

Setting the module parameters noaccel=1 and runpm=0 will fix it.

https://phabricator.endlessm.com/T23280

Signed-off-by: Chris Chiu <chiu@endlessm.com>