### PR TITLE
radeon: Disable runtime pm on Acer Veriton Z4660G

### DIFF
--- a/drivers/gpu/drm/radeon/radeon_drv.c
+++ b/drivers/gpu/drm/radeon/radeon_drv.c
@@ -44,6 +44,8 @@
 
 #include <drm/drm_crtc_helper.h>
 
+#include <linux/dmi.h>
+
 /*
  * KMS wrapper.
  * - 2.0.0 - initial interface
@@ -337,6 +339,17 @@ static int radeon_kick_out_firmware_fb(struct pci_dev *pdev)
 	return 0;
 }
 
+static const struct dmi_system_id disable_runpm[] = {
+	{
+		.ident = "Acer, Veriton Z4660G",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z4660G"),
+		},
+	},
+	{}
+};
+
 static int radeon_pci_probe(struct pci_dev *pdev,
 			    const struct pci_device_id *ent)
 {
@@ -349,6 +362,10 @@ static int radeon_pci_probe(struct pci_dev *pdev,
 	ret = radeon_kick_out_firmware_fb(pdev);
 	if (ret)
 		return ret;
+
+	/* Disable runtime pm, if it is in the blacklist */
+	if (dmi_first_match(disable_runpm))
+		radeon_runtime_pm = 0;
 
 	return drm_get_pci_dev(pdev, ent, &kms_driver);
 }


### PR DESCRIPTION
Radeon on the desktop like Acer Veriton Z4660G hits the errors during
booting which makes the Xorg cannot start.

[   31.576037] [drm:atom_op_jump [radeon]] *ERROR* atombios stuck in
loop for more than 5secs aborting
[   31.576058] [drm:atom_execute_table_locked [radeon]] *ERROR* atombios
stuck executing 67C0 (len 254, WS 0, PS 4) @ 0x67CE
[   31.576064] [drm:atom_execute_table_locked [radeon]] *ERROR* atombios
stuck executing 612C (len 78, WS 12, PS 8) @ 0x6165
[   31.928696] radeon 0000:01:00.0: Wait for MC idle timedout !
[   32.099173] radeon 0000:01:00.0: Wait for MC idle timedout !
[   32.105505] radeon 0000:01:00.0: WB enabled
[   32.105506] radeon 0000:01:00.0: fence driver on ring 0 use gpu addr
0x0000000080000c00 and cpu addr 0x00000000789d04f1
[   32.105507] radeon 0000:01:00.0: fence driver on ring 1 use gpu addr
0x0000000080000c04 and cpu addr 0x00000000e97b01fe
[   32.105508] radeon 0000:01:00.0: fence driver on ring 2 use gpu addr
0x0000000080000c08 and cpu addr 0x00000000d4f9b704
[   32.105509] radeon 0000:01:00.0: fence driver on ring 3 use gpu addr
0x0000000080000c0c and cpu addr 0x000000003c3a5095
[   32.105509] radeon 0000:01:00.0: fence driver on ring 4 use gpu addr
0x0000000080000c10 and cpu addr 0x0000000039af488d
[   32.631109] [drm:r600_ring_test [radeon]] *ERROR* radeon: ring 0 test
failed (scratch(0x850C)=0xCAFEDEAD)
[   32.631119] [drm:si_resume [radeon]] *ERROR* si startup failed on
resume

This patch disbles the radeon's runtime pm to fix the issue.

https://phabricator.endlessm.com/T23948

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>