### PR TITLE
i915: disable framebuffer compression on GeminiLake

### DIFF
--- a/drivers/gpu/drm/i915/intel_fbc.c
+++ b/drivers/gpu/drm/i915/intel_fbc.c
@@ -1372,6 +1372,10 @@ static int intel_sanitize_fbc_option(struct drm_i915_private *dev_priv)
 	if (!HAS_FBC(dev_priv))
 		return 0;
 
+	/* https://bugs.freedesktop.org/show_bug.cgi?id=108085 */
+	if (IS_GEMINILAKE(dev_priv))
+		return 0;
+
 	if (IS_BROADWELL(dev_priv) || INTEL_GEN(dev_priv) >= 9)
 		return 1;
 


### PR DESCRIPTION
On many (all?) the Gemini Lake systems we work with, there is frequent
momentary graphical corruption at the top of the screen, and it
seems that disabling framebuffer compression can avoid this.

Disable fbc on GeminiLake until a solution is found.

https://bugs.freedesktop.org/show_bug.cgi?id=108085
https://phabricator.endlessm.com/T21409