### PR TITLE
ACPI / battery: Fix reporting "Not charging" when capacity is 100%

### DIFF
--- a/drivers/acpi/battery.c
+++ b/drivers/acpi/battery.c
@@ -217,8 +217,12 @@ static int acpi_battery_handle_discharging(struct acpi_battery *battery)
 	 * was plugged in and the device thus did not start a new charge cycle.
 	 */
 	if ((battery_ac_is_broken || power_supply_is_system_supplied()) &&
-	    battery->rate_now == 0)
+	    battery->rate_now == 0) {
+		if (battery->capacity_now && battery->full_charge_capacity &&
+		    battery->capacity_now / battery->full_charge_capacity == 1)
+			return POWER_SUPPLY_STATUS_FULL;
 		return POWER_SUPPLY_STATUS_NOT_CHARGING;
+	}
 
 	return POWER_SUPPLY_STATUS_DISCHARGING;
 }


### PR DESCRIPTION
Commit 19fffc8450d4378580a8f019b195c4617083176f fixed reporting
"Discharging" on some machines when AC was connected but the battery was
not charging. But now on these machines the battery status is reported
as "Not charging" even when the battery is fully charged.

This commit takes the battery capacity into consideration when checking
if "Not charging" should be returned and "Full" is returned when the
capacity is 100%.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T24044