### PR TITLE
radeon: Disable runtime pm on Acer Veriton Z4860G/Z6860G

### DIFF
--- a/drivers/gpu/drm/radeon/radeon_drv.c
+++ b/drivers/gpu/drm/radeon/radeon_drv.c
@@ -347,6 +347,20 @@ static const struct dmi_system_id disable_runpm[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z4660G"),
 		},
 	},
+	{
+		.ident = "Acer, Veriton Z4860G",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z4860G"),
+		},
+	},
+	{
+		.ident = "Acer, Veriton Z6860G",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z6860G"),
+		},
+	},
 	{}
 };
 


### PR DESCRIPTION
Some Acer AIO desktops like Veriton Z4860G and Z6860G cannot boot into
desktop environment without disabling runtime PM of the AMD Radeon VGA
card R5-330.

https://phabricator.endlessm.com/T23948

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>