### PR TITLE
ALSA: hda/realtek: Enable internal speaker of ASUS UX333FA with ALC294

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -5561,12 +5561,13 @@ enum {
 	ALC282_FIXUP_ACER_TRAVELMATE_PINS,
 	ALC255_FIXUP_ACER_LIMIT_INT_MIC_BOOST,
 	ALC269VC_FIXUP_ACER_VCOPPERBOX_PINS,
-	ALC294_FIXUP_ASUS_SPK_NOISE,
 	ALC256_FIXUP_ACER_SWIFT_NO_MIC_PRESENCE,
 	ALC256_FIXUP_ACER_SWIFT_DISABLE_AAMIX,
 	ALC295_FIXUP_HP_X360,
 	ALC221_FIXUP_HP_HEADSET_MIC,
 	ALC285_FIXUP_LENOVO_HEADPHONE_NOISE,
+	ALC294_FIXUP_ASUS_HEADSET_MIC,
+	ALC294_FIXUP_ASUS_SPK_NOISE,
 };
 
 static const struct hda_fixup alc269_fixups[] = {
@@ -6498,17 +6499,6 @@ static const struct hda_fixup alc269_fixups[] = {
 		.chained = true,
 		.chain_id = ALC269_FIXUP_HEADSET_MODE
 	},
-	[ALC294_FIXUP_ASUS_SPK_NOISE] = {
-		.type = HDA_FIXUP_VERBS,
-		.v.verbs = (const struct hda_verb[]) {
-			/* Set EAPD high */
-			{0x20, AC_VERB_SET_COEF_INDEX, 0x10},
-			{0x20, AC_VERB_SET_PROC_COEF, 0x14},
-			{}
-		},
-		.chained = true,
-		.chain_id = ALC255_FIXUP_ASUS_MIC_NO_PRESENCE
-	},
 	[ALC256_FIXUP_ACER_SWIFT_NO_MIC_PRESENCE] = {
 		.type = HDA_FIXUP_PINS,
 		.v.pins = (const struct hda_pintbl[]) {
@@ -6543,6 +6533,28 @@ static const struct hda_fixup alc269_fixups[] = {
 	[ALC285_FIXUP_LENOVO_HEADPHONE_NOISE] = {
 		.type = HDA_FIXUP_FUNC,
 		.v.func = alc285_fixup_invalidate_dacs,
+	},
+	[ALC294_FIXUP_ASUS_HEADSET_MIC] = {
+		.type = HDA_FIXUP_PINS,
+		.v.pins = (const struct hda_pintbl[]) {
+			{ 0x19, 0x01a1113c }, /* use as headset mic, without its own jack detect */
+			{ }
+		},
+		.chained = true,
+		.chain_id = ALC269_FIXUP_HEADSET_MODE_NO_HP_MIC
+	},
+	[ALC294_FIXUP_ASUS_SPK_NOISE] = {
+		.type = HDA_FIXUP_VERBS,
+		.v.verbs = (const struct hda_verb[]) {
+			/* Set EAPD high */
+			{0x20, AC_VERB_SET_COEF_INDEX, 0x10},
+			{0x20, 0x4c4, 0x20},
+			{0x20, AC_VERB_SET_COEF_INDEX, 0x40},
+			{0x20, 0x488, 0x00},
+			{}
+		},
+		.chained = true,
+		.chain_id = ALC294_FIXUP_ASUS_HEADSET_MIC
 	},
 };
 
@@ -7372,7 +7384,6 @@ static const struct snd_hda_pin_quirk alc269_pin_fixup_tbl[] = {
 	SND_HDA_PIN_QUIRK(0x10ec0294, 0x1043, "ASUS", ALC294_FIXUP_ASUS_SPK_NOISE,
 		{0x12, 0x90a60130},
 		{0x17, 0x90170110},
-		{0x19, 0x411111f0},
 		{0x21, 0x04211020}),
 	{}
 };


### PR DESCRIPTION
Apply more HDA verbs of ALC294 to enable the internal speaker of ASUS
UX333FA.

https://phabricator.endlessm.com/T24542

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>