### PR TITLE
Fix rtl8821ce wireless driver build

### DIFF
--- a/drivers/net/wireless/rtl8821ce/Makefile
+++ b/drivers/net/wireless/rtl8821ce/Makefile
@@ -13,6 +13,7 @@ EXTRA_CFLAGS += -Wno-unused-label
 EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
+EXTRA_CFLAGS += -Wno-incompatible-pointer-types
 #EXTRA_CFLAGS += -Wno-uninitialized
 
 GCC_VER_49 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 4.9 | bc )


### PR DESCRIPTION
Suppresses C compilation warning when running `make`.
```
./rtl8821ce/os_dep/linux/os_intfs.c:1325:22: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
  .ndo_select_queue = rtw_select_queue,
```

I understand this is sloppy. I didn't care about getting to the bottom of it, I just wanted to make it work.