### PR TITLE
ALSA: hda: Fix the mic control when headset is plugged

### DIFF
--- a/sound/pci/hda/hda_generic.c
+++ b/sound/pci/hda/hda_generic.c
@@ -148,8 +148,7 @@ static void parse_user_hints(struct hda_codec *codec)
 	if (val >= 0)
 		spec->suppress_auto_mute = !val;
 	val = snd_hda_get_bool_hint(codec, "auto_mic");
-	if (val >= 0)
-		spec->suppress_auto_mic = !val;
+	spec->suppress_auto_mic = 1;
 	val = snd_hda_get_bool_hint(codec, "line_in_auto_switch");
 	if (val >= 0)
 		spec->line_in_auto_switch = !!val;


### PR DESCRIPTION
The internal microphone will not be listed on the report of "amixer -D
sysdefault" if the pin node of headset microphone has auto detection
feature.  When the headset is plugged and user chooses the internal
microphone as the input source, system only gets sound from headset's
microphone.

This patch makes internal microphone be listed whether the headset
microphone pin node is auto detection or not.

https://phabricator.endlessm.com/T24554

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>