### PR TITLE
drm/i915: Clear inteldrmfb's framebuffer on probe

### DIFF
--- a/drivers/gpu/drm/i915/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/intel_fbdev.c
@@ -179,7 +179,6 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	struct drm_framebuffer *fb;
 	struct i915_vma *vma;
 	unsigned long flags = 0;
-	bool prealloc = false;
 	void __iomem *vaddr;
 	int ret;
 
@@ -201,7 +200,6 @@ static int intelfb_create(struct drm_fb_helper *helper,
 		intel_fb = ifbdev->fb;
 	} else {
 		DRM_DEBUG_KMS("re-using BIOS fb\n");
-		prealloc = true;
 		sizes->fb_width = intel_fb->base.width;
 		sizes->fb_height = intel_fb->base.height;
 	}
@@ -265,8 +263,10 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	 * If the object is stolen however, it will be full of whatever
 	 * garbage was left in there.
 	 */
-	if (intel_fb_obj(fb)->stolen && !prealloc)
+	if (intel_fb_obj(fb)->stolen) {
+		DRM_DEBUG_KMS("clearing stolen fb\n");
 		memset_io(info->screen_base, 0, info->screen_size);
+	}
 
 	/* Use default scratch pixmap (info->pixmap.flags = FB_PIXMAP_SYSTEM) */
 


### PR DESCRIPTION
The firmware framebuffer is re-used as inteldrmfb's framebuffer to have
a seamless firmware -> bootloader -> efifb -> inteldrmfb transition.
Since inteldrmfb's framebuffer is also used as a fallback when clients
remove the scan-out buffer, we end-up having the BGRT image or whatever
else may have been left-over on that framebuffer shown when a drm client
removes its own framebuffer, as that is when the fallback framebuffer is
displayed. In practice this happens on shutdown, when the user session
and GDM remove their framebuffers and before Plymouth installs its own
framebuffer using the DRM API to show the shutdown splash, and on logout
if GDM's greeter is not active, when the user session and GDM remove
their framebuffers and before GDM's greeter starts again and installs
its own framebuffer to show the user selection menu.

To work around this problem, we can clear inteldrmfb's framebuffer when
creating it, so we have a clean black screen as fallback.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>