### PR TITLE
x86/reboot: Use efi reboot for Acer TravelMate X514-51T

### DIFF
--- a/arch/x86/kernel/reboot.c
+++ b/arch/x86/kernel/reboot.c
@@ -82,6 +82,19 @@ static int __init set_bios_reboot(const struct dmi_system_id *d)
 	return 0;
 }
 
+/*
+ * Some machines require the "reboot=e" commandline options
+ */
+static int __init set_efi_reboot(const struct dmi_system_id *d)
+{
+	if (reboot_type != BOOT_EFI) {
+		reboot_type = BOOT_EFI;
+		pr_info("%s series board detected. Selecting %s-method for reboot.\n",
+			d->ident, "EFI");
+	}
+	return 0;
+}
+
 void __noreturn machine_real_restart(unsigned int type)
 {
 	local_irq_disable();
@@ -165,6 +178,14 @@ static const struct dmi_system_id reboot_dmi_table[] __initconst = {
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "AOA110"),
+		},
+	},
+	{	/* Handle reboot issue on Acer TravelMate X514-51T */
+		.callback = set_efi_reboot,
+		.ident = "Acer TravelMate X514-51T",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "TravelMate X514-51T"),
 		},
 	},
 


### PR DESCRIPTION
Laptops like Acer TravelMate X514-51T cannot reboot (hang in the BIOS
POST when reboot) until set it as efi reboot.

https://phabricator.endlessm.com/T25190

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>