### PR TITLE
Revert "radeon: Disable runtime pm on Acer Veriton Z4860G/Z6860G"

### DIFF
--- a/drivers/gpu/drm/radeon/radeon_drv.c
+++ b/drivers/gpu/drm/radeon/radeon_drv.c
@@ -326,20 +326,6 @@ static const struct dmi_system_id disable_runpm[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z4660G"),
 		},
 	},
-	{
-		.ident = "Acer, Veriton Z4860G",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z4860G"),
-		},
-	},
-	{
-		.ident = "Acer, Veriton Z6860G",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Veriton Z6860G"),
-		},
-	},
 	{}
 };
 


### PR DESCRIPTION
This reverts commit 9ac6fc2321925aacf2c41e2b6f4ec0335bfa8603.
https://phabricator.endlessm.com/T24062