### PR TITLE
drm/amdgpu: Disable runtime pm for Acer Aspire A315-21G

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
@@ -32,6 +32,7 @@
 #include <linux/module.h>
 #include <linux/pm_runtime.h>
 #include <linux/vga_switcheroo.h>
+#include <linux/dmi.h>
 #include <drm/drm_crtc_helper.h>
 
 #include "amdgpu.h"
@@ -907,13 +908,31 @@ MODULE_DEVICE_TABLE(pci, pciidlist);
 
 static struct drm_driver kms_driver;
 
+static const struct dmi_system_id amdgpu_runpm_zero_list[] = {
+	{
+		.ident = "Acer Aspire A315-21G",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A315-21G"),
+		},
+	},
+	{ }
+};
+
 static int amdgpu_pci_probe(struct pci_dev *pdev,
 			    const struct pci_device_id *ent)
 {
+	const struct dmi_system_id *dmi_id;
 	struct drm_device *dev;
 	unsigned long flags = ent->driver_data;
 	int ret, retry = 0;
 	bool supports_atomic = false;
+
+	/* The amdgpu.runpm=0 DMI quirk */
+	if ((dmi_id = dmi_first_match(amdgpu_runpm_zero_list))) {
+		DRM_INFO("Disable runtime pm by matching %s\n", dmi_id->ident);
+		amdgpu_runtime_pm = 0;
+	}
 
 	if (!amdgpu_virtual_display &&
 	    amdgpu_device_asic_has_dc_support(flags & AMD_ASIC_MASK))


### PR DESCRIPTION
The Acer Aspire A315-21G cannot boot with the error:

Apr 09 11:28:59 endless kernel: AMD-Vi: Completion-Wait loop timed out
Apr 09 11:28:59 endless kernel: iommu ivhd0: AMD-Vi: Event logged [IOTLB_INV_TIMEOUT device=01:00.0 address=0x216d8e620]

This patch makes a workaround by adding a DMI quirk which disables
amdgpu's runtime pm for this model.

https://phabricator.endlessm.com/T26099

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>