### PR TITLE
Revert "drm/amdgpu: Disable runtime pm for Acer Aspire A315-21G"

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
@@ -32,7 +32,6 @@
 #include <linux/module.h>
 #include <linux/pm_runtime.h>
 #include <linux/vga_switcheroo.h>
-#include <linux/dmi.h>
 #include <drm/drm_crtc_helper.h>
 
 #include "amdgpu.h"
@@ -908,31 +907,13 @@ MODULE_DEVICE_TABLE(pci, pciidlist);
 
 static struct drm_driver kms_driver;
 
-static const struct dmi_system_id amdgpu_runpm_zero_list[] = {
-	{
-		.ident = "Acer Aspire A315-21G",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Aspire A315-21G"),
-		},
-	},
-	{ }
-};
-
 static int amdgpu_pci_probe(struct pci_dev *pdev,
 			    const struct pci_device_id *ent)
 {
-	const struct dmi_system_id *dmi_id;
 	struct drm_device *dev;
 	unsigned long flags = ent->driver_data;
 	int ret, retry = 0;
 	bool supports_atomic = false;
-
-	/* The amdgpu.runpm=0 DMI quirk */
-	if ((dmi_id = dmi_first_match(amdgpu_runpm_zero_list))) {
-		DRM_INFO("Disable runtime pm by matching %s\n", dmi_id->ident);
-		amdgpu_runtime_pm = 0;
-	}
 
 	if (!amdgpu_virtual_display &&
 	    amdgpu_device_asic_has_dc_support(flags & AMD_ASIC_MASK))

--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -4979,6 +4979,7 @@ static void quirk_no_ats(struct pci_dev *pdev)
 
 /* AMD Stoney platform GPU */
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_ATI, 0x98e4, quirk_no_ats);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_ATI, 0x6900, quirk_no_ats);
 #endif /* CONFIG_PCI_ATS */
 
 /* Freescale PCIe doesn't support MSI in RC mode */


### PR DESCRIPTION
This reverts commit 9d19ad0.
Upstreams uses the the patch [1] to fix the issue for now.

https://phabricator.endlessm.com/T26211

[1]: https://patchwork.kernel.org/patch/10889269/