### PR TITLE
Revert "Bluetooth: Add new Realtek 8822BE ID 13d3:3526"

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -391,7 +391,6 @@ static const struct usb_device_id blacklist_table[] = {
 	/* Additional Realtek 8822BE Bluetooth devices */
 	{ USB_DEVICE(0x13d3, 0x3526), .driver_info = BTUSB_REALTEK },
 	{ USB_DEVICE(0x0b05, 0x185c), .driver_info = BTUSB_REALTEK },
-	{ USB_DEVICE(0x13d3, 0x3526), .driver_info = BTUSB_REALTEK },
 
 	/* Silicon Wave based devices */
 	{ USB_DEVICE(0x0c10, 0x0000), .driver_info = BTUSB_SWAVE },


### PR DESCRIPTION
This reverts commit 644ee83acc02843cab015332863940ebb3fda1e4.

This USB id is now present upstream, so we are adding an extra entry to
the list to no effect.