### PR TITLE
Revert "ALSA: hda - Enforces runtime_resume after S3 and S4 for each codec"

### DIFF
--- a/sound/pci/hda/hda_codec.c
+++ b/sound/pci/hda/hda_codec.c
@@ -2952,20 +2952,6 @@ static int hda_codec_runtime_resume(struct device *dev)
 #endif /* CONFIG_PM */
 
 #ifdef CONFIG_PM_SLEEP
-static int hda_codec_force_resume(struct device *dev)
-{
-	int ret;
-
-	/* The get/put pair below enforces the runtime resume even if the
-	 * device hasn't been used at suspend time.  This trick is needed to
-	 * update the jack state change during the sleep.
-	 */
-	pm_runtime_get_noresume(dev);
-	ret = pm_runtime_force_resume(dev);
-	pm_runtime_put(dev);
-	return ret;
-}
-
 static int hda_codec_pm_suspend(struct device *dev)
 {
 	dev->power.power_state = PMSG_SUSPEND;
@@ -2975,7 +2961,7 @@ static int hda_codec_pm_suspend(struct device *dev)
 static int hda_codec_pm_resume(struct device *dev)
 {
 	dev->power.power_state = PMSG_RESUME;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 
 static int hda_codec_pm_freeze(struct device *dev)
@@ -2987,13 +2973,13 @@ static int hda_codec_pm_freeze(struct device *dev)
 static int hda_codec_pm_thaw(struct device *dev)
 {
 	dev->power.power_state = PMSG_THAW;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 
 static int hda_codec_pm_restore(struct device *dev)
 {
 	dev->power.power_state = PMSG_RESTORE;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 #endif /* CONFIG_PM_SLEEP */
 


### PR DESCRIPTION
After suspending the device and bringing it back up the audio playback
does not work anymore. The device for sound output is listed as a
headphone device. Plugging in headphones no sound is audible neither.

This reverts commit 9c51afaceb61459d2becac8fb32c860bb084e643 to solve
this regression issue.

https://phabricator.endlessm.com/T26524