### PR TITLE
Bluetooth: btrtl: HCI reset on close for RTL8822BE

### DIFF
--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -640,6 +640,10 @@ int btrtl_setup_realtek(struct hci_dev *hdev)
 		return PTR_ERR(btrtl_dev);
 
 	ret = btrtl_download_firmware(hdev, btrtl_dev);
+	/* According to the vendor driver, BT must be reset on close to avoid
+	 * firmware crash since kernel v3.7.1.
+	 */
+	set_bit(HCI_QUIRK_RESET_ON_CLOSE, &hdev->quirks);
 
 	btrtl_free(btrtl_dev);
 


### PR DESCRIPTION
Realtek RTL8822BE BT chip on ASUS X420FA cannot be turned on correctly
after on-off several times.  Bluetooth daemon sets BT mode failed when
this issue happens.

bluetoothd[1576]: Failed to set mode: Failed (0x03)

If BT is tunred off, then turned on again, it works correctly again.
This patch makes RTL8822BE BT reset on close to fix this issue.

https://phabricator.endlessm.com/T26102

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>