### PR TITLE
Add Endless PAYG LSM

### DIFF
--- a/security/Kconfig
+++ b/security/Kconfig
@@ -317,7 +317,7 @@ config LSM
 	default "yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo" if DEFAULT_SECURITY_APPARMOR
 	default "yama,loadpin,safesetid,integrity,tomoyo" if DEFAULT_SECURITY_TOMOYO
 	default "yama,loadpin,safesetid,integrity" if DEFAULT_SECURITY_DAC
-	default "yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
+	default "endlesspayg,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
 	help
 	  A comma-separated list of LSMs, in initialization order.
 	  Any LSMs left off this list will be ignored. This can be

--- a/security/Makefile
+++ b/security/Makefile
@@ -9,6 +9,7 @@ subdir-$(CONFIG_SECURITY_SMACK)		+= smack
 subdir-$(CONFIG_SECURITY_TOMOYO)        += tomoyo
 subdir-$(CONFIG_SECURITY_APPARMOR)	+= apparmor
 subdir-$(CONFIG_SECURITY_YAMA)		+= yama
+subdir-$(CONFIG_SECURITY)		+= endlesspayg
 subdir-$(CONFIG_SECURITY_LOADPIN)	+= loadpin
 subdir-$(CONFIG_SECURITY_SAFESETID)    += safesetid
 
@@ -25,6 +26,7 @@ obj-$(CONFIG_AUDIT)			+= lsm_audit.o
 obj-$(CONFIG_SECURITY_TOMOYO)		+= tomoyo/
 obj-$(CONFIG_SECURITY_APPARMOR)		+= apparmor/
 obj-$(CONFIG_SECURITY_YAMA)		+= yama/
+obj-$(CONFIG_SECURITY)			+= endlesspayg/
 obj-$(CONFIG_SECURITY_LOADPIN)		+= loadpin/
 obj-$(CONFIG_SECURITY_SAFESETID)       += safesetid/
 obj-$(CONFIG_CGROUP_DEVICE)		+= device_cgroup.o

--- a/security/endlesspayg/Makefile
+++ b/security/endlesspayg/Makefile
@@ -1,0 +1,1 @@
+obj-y += endlesspayg.o

--- a/security/endlesspayg/endlesspayg.c
+++ b/security/endlesspayg/endlesspayg.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * LSM for PAYG security
+ * Copyright (C) 2019 Endless Mobile, Inc.
+ */
+
+#include <linux/dcache.h>
+#include <linux/fs.h>
+#include <linux/lsm_hooks.h>
+#include <linux/security.h>
+#include <linux/kernel.h>
+#include <linux/types.h>
+
+static struct dentry *payg_dir;
+static struct dentry *paygd_pid_file;
+static pid_t paygd_pid = -1;
+
+static int payg_ptrace_access_check(struct task_struct *child,
+				    unsigned int mode)
+{
+	/* Disallow tracing of paygd */
+	if (paygd_pid >= 0 && child->pid == paygd_pid)
+		return -EACCES;
+
+	return 0;
+}
+
+static struct security_hook_list payg_hooks[] __lsm_ro_after_init = {
+	LSM_HOOK_INIT(ptrace_access_check, payg_ptrace_access_check),
+};
+
+/* Set paygd PID. Can only be done if it is not already set. */
+static ssize_t paygd_pid_file_write(struct file *filp,
+				    const char __user *buf,
+				    size_t count, loff_t *ppos)
+{
+	int ret;
+
+	if (paygd_pid != -1)
+		return -EACCES;
+
+	ret = kstrtoint_from_user(buf, count, 10, &paygd_pid);
+	if (ret != 0)
+		return -EINVAL;
+
+	return count;
+}
+
+static const struct file_operations paygd_pid_file_ops = {
+	.write = paygd_pid_file_write,
+	.llseek = generic_file_llseek,
+};
+
+static int __init payg_lsm_init(void)
+{
+	security_add_hooks(payg_hooks, ARRAY_SIZE(payg_hooks),
+			   "endlesspayg");
+	return 0;
+}
+
+DEFINE_LSM(endlesspayg) = {
+	.name = "endlesspayg",
+	.init = payg_lsm_init,
+};
+
+static int __init payg_init_securityfs(void)
+{
+	payg_dir = securityfs_create_dir("endlesspayg", NULL);
+	if (IS_ERR(payg_dir))
+		return PTR_ERR(payg_dir);
+
+	paygd_pid_file = securityfs_create_file("paygd_pid",
+						S_IWUSR, payg_dir, NULL,
+						&paygd_pid_file_ops);
+	if (IS_ERR(paygd_pid_file)) {
+		securityfs_remove(payg_dir);
+		return PTR_ERR(paygd_pid_file);
+	}
+
+	return 0;
+}
+fs_initcall(payg_init_securityfs);


### PR DESCRIPTION
Allow the paygd PID to be set through
/sys/kernel/security/endlesspayg/paygd_pid

When set, paygd can no longer be ptraced.

https://phabricator.endlessm.com/T27045