### PR TITLE
rtl8723bu: always indicate disconnect during netdev_close

### DIFF
--- a/drivers/net/wireless/rtl8723bu/os_dep/os_intfs.c
+++ b/drivers/net/wireless/rtl8723bu/os_dep/os_intfs.c
@@ -2456,7 +2456,6 @@ static int netdev_close(struct net_device *pnetdev)
 				rtw_netif_stop_queue(pnetdev);
 		}
 
-#ifndef CONFIG_ANDROID
 		//s2.
 		LeaveAllPowerSaveMode(padapter);
 		rtw_disassoc_cmd(padapter, 500, _FALSE);
@@ -2466,7 +2465,6 @@ static int netdev_close(struct net_device *pnetdev)
 		rtw_free_assoc_resources(padapter, 1);
 		//s2-4.
 		rtw_free_network_queue(padapter,_TRUE);
-#endif
 		// Close LED
 		rtw_led_control(padapter, LED_CTL_POWER_OFF);
 	}


### PR DESCRIPTION
In eos3.5, CONFIG_ANDROID=n, so we were running this code, which
we've previously documented as being the essential thing to tell
cfg80211 that we've disconnected in the suspend/resume path.

In eos3.6, CONFIG_ANDROID=y so we were no longer doing this.
After suspend/resume, wifi reconnection is broken as a result.

"Fix" this by restoring the eos3.5 behaviour of running this codepath.

https://phabricator.endlessm.com/T20835
https://phabricator.endlessm.com/T27164