### PR TITLE
config: allow endlesspayg LSM to pass packaging checks

### DIFF
--- a/debian.master/config/annotations
+++ b/debian.master/config/annotations
@@ -12483,7 +12483,7 @@ CONFIG_STATIC_USERMODEHELPER                    policy<{'amd64': 'n', 'arm64': '
 CONFIG_LOCK_DOWN_KERNEL                         policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'n', 's390x': 'n'}>
 CONFIG_LOCK_DOWN_KERNEL_FORCE                   policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'i386': 'n'}>
 CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT             policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y'}>
-CONFIG_LSM                                      policy<{'amd64': '"yama,loadpin,integrity,apparmor"', 'arm64': '"yama,loadpin,integrity,apparmor"', 'armhf': '"yama,loadpin,integrity,apparmor"', 'i386': '"yama,loadpin,integrity,apparmor"', 'ppc64el': '"yama,loadpin,integrity,apparmor"', 's390x': '"yama,loadpin,integrity,apparmor"'}>
+CONFIG_LSM                                      policy<{'amd64': '"endlesspayg,yama,loadpin,integrity,apparmor"', 'arm64': '"endlesspayg,yama,loadpin,integrity,apparmor"', 'armhf': '"endlesspayg,yama,loadpin,integrity,apparmor"', 'i386': '"endlesspayg,yama,loadpin,integrity,apparmor"', 'ppc64el': '"endlesspayg,yama,loadpin,integrity,apparmor"', 's390x': '"endlesspayg,yama,loadpin,integrity,apparmor"'}>
 #
 CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT             mark<ENFORCED>
 CONFIG_LOCK_DOWN_KERNEL                         mark<ENFORCED> flag<REVIEW>


### PR DESCRIPTION
Turning on our LSM broke the build because the packaging strictly
enforces certain LSM options.  Add our LSM to those.

https://phabricator.endlessm.com/T27045