### PR TITLE
Endless packaging customization

### DIFF
--- a/debian.master/control.stub.in
+++ b/debian.master/control.stub.in
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>
 Standards-Version: 3.9.4.0
 Build-Depends:
+ eos-initramfs-efi,
  debhelper (>= 9),
  dh-systemd,
  cpio,


### PR DESCRIPTION
This adds the initramfs for our PAYG images to the linux-image
package.

https://phabricator.endlessm.com/T27042