### PR TITLE
Endless Packaging Customization

### DIFF
--- a/debian.master/rules.d/amd64.mk
+++ b/debian.master/rules.d/amd64.mk
@@ -23,3 +23,4 @@ do_tools_acpidbg = true
 do_zfs		= true
 do_dkms_nvidia  = true
 do_dkms_vbox    = true
+do_efi_blob     = true

--- a/debian/rules.d/2-binary-arch.mk
+++ b/debian/rules.d/2-binary-arch.mk
@@ -334,7 +334,8 @@ endif
 	# Now the header scripts
 	$(call install_control,$(hdrs_pkg_name)-$*,headers,postinst)
 
-	# Endless PAYG: Create an initramfs image with dracut
+# Endless PAYG: Create an initramfs image with dracut
+ifeq ($(do_efi_blob),true)
 	# Start by combining modules and modules-extra into a single temp
 	# directory and running depmod, so dracut can build an image with
 	# extra modules like bfq and i915.
@@ -353,6 +354,7 @@ endif
 		--kernel-cmdline "rw"
 	# Delete our module temp directory
 	rm -rf $(CURDIR)/debian/linux-modules-temp
+endif
 
 	# At the end of the package prep, call the tests
 	DPKG_ARCH="$(arch)" KERN_ARCH="$(build_arch)" FLAVOUR="$*"	\


### PR DESCRIPTION
Make efi payg images per-arch optional, only enable for amd64

https://phabricator.endlessm.com/T27042