### PR TITLE
endlesspayg: Block proc populating for LSM user

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -99,6 +99,7 @@
 #include "fd.h"
 
 #include "../../lib/kstrtox.h"
+#include "../../security/endlesspayg/endlesspayg.h"
 
 /* NOTE:
  *	Implementing inode permission operations in /proc is almost
@@ -2451,6 +2452,8 @@ static struct dentry *proc_pident_lookup(struct inode *dir,
 	if (!task)
 		goto out_no_task;
 
+	if (!eospayg_proc_pid_is_safe(task->pid))
+		goto out_payg_filtered;
 	/*
 	 * Yes, it does not scale. And it should not. Don't add
 	 * new entries into /proc/<tgid>/ without very good reasons.
@@ -2463,6 +2466,7 @@ static struct dentry *proc_pident_lookup(struct inode *dir,
 			break;
 		}
 	}
+out_payg_filtered:
 	put_task_struct(task);
 out_no_task:
 	return res;
@@ -2476,6 +2480,9 @@ static int proc_pident_readdir(struct file *file, struct dir_context *ctx,
 
 	if (!task)
 		return -ENOENT;
+
+	if (!eospayg_proc_pid_is_safe(task->pid))
+		goto out;
 
 	if (!dir_emit_dots(file, ctx))
 		goto out;

--- a/security/endlesspayg/endlesspayg.c
+++ b/security/endlesspayg/endlesspayg.c
@@ -42,6 +42,17 @@ bool eospayg_skip_name_wide(const u16 *name)
 	return false;
 }
 
+bool eospayg_proc_pid_is_safe(pid_t pid)
+{
+	if (paygd_pid < 0)
+		return true;
+
+	if (pid == paygd_pid)
+		return false;
+
+	return true;
+}
+
 static bool is_payg_master(void)
 {
 	/* If payg isn't enforced, treat everyone like master */

--- a/security/endlesspayg/endlesspayg.h
+++ b/security/endlesspayg/endlesspayg.h
@@ -9,5 +9,6 @@
 
 bool eospayg_skip_name(const char *name);
 bool eospayg_skip_name_wide(const u16 *name);
+bool eospayg_proc_pid_is_safe(pid_t tid);
 
 #endif /* _SECURITY_ENDLESSPAYG_H */


### PR DESCRIPTION
Stop the pid directory in proc from being populated for the holder
of the LSM

https://phabricator.endlessm.com/T27044