### PR TITLE
ACPI: PM: Set s2idle_wakeup earlier and clear it later

### DIFF
--- a/drivers/acpi/sleep.c
+++ b/drivers/acpi/sleep.c
@@ -972,6 +972,8 @@ static int acpi_s2idle_prepare(void)
 	/* Change the configuration of GPEs to avoid spurious wakeup. */
 	acpi_enable_all_wakeup_gpes();
 	acpi_os_wait_events_complete();
+
+	s2idle_wakeup = true;
 	return 0;
 }
 
@@ -991,7 +993,6 @@ static void acpi_s2idle_wake(void)
 	if (acpi_sci_irq_valid() &&
 	    !irqd_is_wakeup_armed(irq_get_irq_data(acpi_sci_irq))) {
 		pm_system_cancel_wakeup();
-		s2idle_wakeup = true;
 		/*
 		 * On some platforms with the LPS0 _DSM device noirq resume
 		 * takes too much time for EC wakeup events to survive, so look
@@ -1012,11 +1013,12 @@ static void acpi_s2idle_sync(void)
 	acpi_os_wait_events_complete();	/* synchronize SCI IRQ handling */
 	acpi_ec_flush_work();
 	acpi_os_wait_events_complete();	/* synchronize Notify handling */
-	s2idle_wakeup = false;
 }
 
 static void acpi_s2idle_restore(void)
 {
+	s2idle_wakeup = false;
+
 	acpi_enable_all_runtime_gpes();
 
 	acpi_disable_wakeup_devices(ACPI_STATE_S0);


### PR DESCRIPTION
The role of the s2idle_wakeup variable is to cause
acpi_pm_wakeup_event() and acpi_pm_notify_handler() to
increment pm_abort_suspend and trigger a wakeup from
suspend-to-idle in case the ACPI SCI wakeup was canceled
by acpi_s2idle_wake().

However, for this purpose it need not be set in acpi_s2idle_wake()
and cleared in acpi_s2idle_sync(), respectively.  In fact, it
may be set as early as in acpi_s2idle_prepare() and cleared as
late as in acpi_s2idle_restore(), so do that to allow subsequent
changes to be simpler.

This change is not expected to alter functionality.

Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Acked-by: Thomas Gleixner <tglx@linutronix.de>