### PR TITLE
endlesspayg: Allow blocking a single device

### DIFF
--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -57,6 +57,8 @@
 #include "quirks.h"
 #include "sd_ops.h"
 
+#include "../../../security/endlesspayg/endlesspayg.h"
+
 MODULE_ALIAS("mmc:block");
 #ifdef MODULE_PARAM_PREFIX
 #undef MODULE_PARAM_PREFIX
@@ -305,6 +307,10 @@ static int mmc_blk_open(struct block_device *bdev, fmode_t mode)
 {
 	struct mmc_blk_data *md = mmc_blk_get(bdev->bd_disk);
 	int ret = -ENXIO;
+
+
+	if (!eospayg_dev_is_safe(bdev->bd_dev))
+		return -EPERM;
 
 	mutex_lock(&block_mutex);
 	if (md) {

--- a/security/endlesspayg/endlesspayg.h
+++ b/security/endlesspayg/endlesspayg.h
@@ -7,6 +7,7 @@
 #ifndef _SECURITY_ENDLESSPAYG_H
 #define _SECURITY_ENDLESSPAYG_H
 
+bool eospayg_dev_is_safe(dev_t d);
 bool eospayg_skip_name(const char *name);
 bool eospayg_skip_name_wide(const u16 *name);
 bool eospayg_proc_pid_is_safe(pid_t tid);


### PR DESCRIPTION
Add an ioctl that lets the LSM user request a block on a single device.

https://phabricator.endlessm.com/T28442