### PR TITLE
Revert "iwlwifi: mvm: fix scan config command size"

### DIFF
--- a/drivers/net/wireless/intel/iwlwifi/mvm/scan.c
+++ b/drivers/net/wireless/intel/iwlwifi/mvm/scan.c
@@ -1220,7 +1220,7 @@ static int iwl_mvm_legacy_config_scan(struct iwl_mvm *mvm)
 		cmd_size = sizeof(struct iwl_scan_config_v2);
 	else
 		cmd_size = sizeof(struct iwl_scan_config_v1);
-	cmd_size += num_channels;
+	cmd_size += mvm->fw->ucode_capa.n_scan_channels;
 
 	cfg = kzalloc(cmd_size, GFP_KERNEL);
 	if (!cfg)


### PR DESCRIPTION
The Intel(R) Dual Band Wireless AC 9461 WiFi keeps restarting until
commit 06eb547c4ae4 ("iwlwifi: mvm: fix scan config command size") is
reverted.

https://phabricator.endlessm.com/T28926

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>