### PR TITLE
PCI: Disable AER for CFL 0xa334 with Atheros Killer E2500 ethernet

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2512,6 +2512,30 @@ static void quirk_disable_rtl_aspm(struct pci_dev *dev)
 DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_VENDOR_ID_INTEL, PCI_ANY_ID,
 			      PCI_CLASS_BRIDGE_PCI, 8, quirk_disable_rtl_aspm);
 
+/* Qualcomm Atheros Killer E2500 ethernet on Intel coffee lake chipset 0xa334
+ * cause a huge spam of pcieport AER errors. This is probably a bug in Linux
+ * since it does not manage to clear the error condition. Until properly fixed,
+ * work around here by disabling AER on affected systems.
+ */
+static void quirk_disable_alx_aer(struct pci_dev *dev)
+{
+	struct pci_dev *child;
+
+	if (!dev->subordinate)
+		return;
+
+	list_for_each_entry(child, &dev->subordinate->devices, bus_list) {
+		if (child->vendor == PCI_VENDOR_ID_ATTANSIC &&
+		    child->device == 0xe0b1) {
+			dev_warn(&child->dev,
+				 "CFL + Atheros Killer E2500; disabling AER\n");
+			pci_no_aer();
+			return;
+		}
+	}
+}
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa334, quirk_disable_alx_aer);
+
 /*
  * The APC bridge device in AMD 780 family northbridges has some random
  * OEM subsystem ID in its vendor ID register (erratum 18), so instead


### PR DESCRIPTION
Qualcomm Atheros Killer E2500 ethernet on Intel coffee lake chipset
0xa334 causes huge amount of PCIe AER error spam, but the functions work
fine.

pcieport 0000:00:1d.0: AER: Corrected error received: 0000:07:00.0
alx 0000:07:00.0: AER: PCIe Bus Error: severity=Corrected, type=Data Link Layer, (Receiver ID)
alx 0000:07:00.0: AER:   device [1969:e0b1] error status/mask=00000040/00002000
alx 0000:07:00.0: AER:    [ 6] BadTLP

This workaround is intentionally restricted to CFL 0xa334 where the
Qualcomm Atheros Killer E2500 ethernet presents behind the quirked PCI
bridge, in order to avoid side effects on other systems

https://phabricator.endlessm.com/T29786

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>