### PR TITLE
Revert "ACPI: PM: s2idle: Prevent spurious SCIs from waking up the system"

### DIFF
--- a/drivers/acpi/sleep.c
+++ b/drivers/acpi/sleep.c
@@ -999,17 +999,10 @@ static bool acpi_s2idle_wake(void)
 		if (acpi_any_fixed_event_status_set())
 			return true;
 
-		/*
-		 * If there are no EC events to process and at least one of the
-		 * other enabled GPEs is active, the wakeup is regarded as a
-		 * genuine one.
-		 *
-		 * Note that the checks below must be carried out in this order
-		 * to avoid returning prematurely due to a change of the EC GPE
-		 * status bit from unset to set between the checks with the
-		 * status bits of all the other GPEs unset.
+		/* If there are no EC events to process, the wakeup is regarded
+		 * as a genuine one.
 		 */
-		if (acpi_any_gpe_status_set() && !acpi_ec_dispatch_gpe())
+		if (!acpi_ec_dispatch_gpe())
 			return true;
 
 		/*


### PR DESCRIPTION
This reverts commit a2ad686c07d3d53558aae56a80a4a929b7e75e03.

The ECS EF20EA hangs during resume from s2idle by a keystroke
problem will be gone after this. Revert it until a better solution
from upstream.

https://phabricator.endlessm.com/T29893