### PR TITLE
ALSA: usb: mixer: volume quirk for ESS Technology Asus USB DAC

### DIFF
--- a/sound/usb/mixer.c
+++ b/sound/usb/mixer.c
@@ -1171,6 +1171,14 @@ static void volume_control_quirks(struct usb_mixer_elem_info *cval,
 			cval->res = 384;
 		}
 		break;
+        case USB_ID(0x0495, 0x3042): /* ESS Technology Asus USB DAC */
+                if ((strstr(kctl->id.name, "Playback Volume") != NULL) ||
+                        strstr(kctl->id.name, "Capture Volume") != NULL) {
+                        cval->min >>= 8;
+                        cval->max = 0;
+                        cval->res = 1;
+                }
+                break;
 	}
 }
 


### PR DESCRIPTION
The Asus USB DAC is a USB type-C audio dongle for connecting to
the headset and headphone. The volume minimum value -23040 which
is 0xa600 in hexdecimal with the resolution value 1 indicates
this should be endianess issue caused by the firmware bug. Add
a volume quirk to fix the volume control problem.

Also fixes this warning:
  Warning! Unlikely big volume range (=23040), cval->res is probably wrong.
  [5] FU [Headset Capture Volume] ch = 1, val = -23040/0/1
  Warning! Unlikely big volume range (=23040), cval->res is probably wrong.
  [7] FU [Headset Playback Volume] ch = 1, val = -23040/0/1

Signed-off-by: Chris Chiu <chiu@endlessm.com>