### PR TITLE
fixup! tmpfs: add user_xattr mount option

### DIFF
--- a/mm/shmem.c
+++ b/mm/shmem.c
@@ -3405,16 +3405,15 @@ static const struct constant_table shmem_param_enums_huge[] = {
 };
 
 const struct fs_parameter_spec shmem_fs_parameters[] = {
-	fsparam_u32   ("gid",		Opt_gid),
-	fsparam_enum  ("huge",		Opt_huge,  shmem_param_enums_huge),
-	fsparam_u32oct("mode",		Opt_mode),
-	fsparam_string("mpol",		Opt_mpol),
-	fsparam_string("nr_blocks",	Opt_nr_blocks),
-	fsparam_string("nr_inodes",	Opt_nr_inodes),
-	fsparam_string("size",		Opt_size),
-	fsparam_u32   ("uid",		Opt_uid),
-	fsparam_bool  ("user_xattr",	Opt_user_xattr),
-	fsparam_bool  ("nouser_xattr",	Opt_nouser_xattr),
+	fsparam_u32    ("gid",		Opt_gid),
+	fsparam_enum   ("huge",		Opt_huge,  shmem_param_enums_huge),
+	fsparam_u32oct ("mode",		Opt_mode),
+	fsparam_string ("mpol",		Opt_mpol),
+	fsparam_string ("nr_blocks",	Opt_nr_blocks),
+	fsparam_string ("nr_inodes",	Opt_nr_inodes),
+	fsparam_string ("size",		Opt_size),
+	fsparam_u32    ("uid",		Opt_uid),
+	fsparam_flag_no("user_xattr",	Opt_nouser_xattr),
 	{}
 };
 
@@ -3432,11 +3431,10 @@ static int shmem_parse_one(struct fs_context *fc, struct fs_parameter *param)
 
 	switch (opt) {
 	case Opt_user_xattr:
-		ctx->user_xattr = true;
-		ctx->seen |= SHMEM_SEEN_USER_XATTR;
-		break;
-	case Opt_nouser_xattr:
-		ctx->user_xattr = false;
+		if (result.boolean)
+			ctx->user_xattr = true;
+		else
+			ctx->user_xattr = false;
 		ctx->seen |= SHMEM_SEEN_USER_XATTR;
 		break;
 	case Opt_size:


### PR DESCRIPTION
We should be using fsparam_no_flag instead of fsparam_bool for this
attribute, otherwise mount expects a value to be passed to the option.

Also, fsparam_no_flag already covers both 'option' and 'nooption', and
we can differentiate them by the result from fs_parse.

This is modeled after fs/erofs/super.c.

https://phabricator.endlessm.com/T30464