### PR TITLE
[Endless] drm/i915: Clear require_force_probe for JSL DRM

### DIFF
--- a/drivers/gpu/drm/i915/i915_pci.c
+++ b/drivers/gpu/drm/i915/i915_pci.c
@@ -842,7 +842,7 @@ static const struct intel_device_info icl_info = {
 static const struct intel_device_info ehl_info = {
 	GEN11_FEATURES,
 	PLATFORM(INTEL_ELKHARTLAKE),
-	.require_force_probe = 1,
+	.require_force_probe = 0,
 	.platform_engine_mask = BIT(RCS0) | BIT(BCS0) | BIT(VCS0) | BIT(VECS0),
 	.ppgtt_size = 36,
 };


### PR DESCRIPTION
We have an ASUS BR1100FKA equipped with Intel N6000 Jasper Lake. The DRM
is always probed failed due to the require_force_probe barrier placed by
Intel. Maybe, Intel has not enabled it well right now, so puts the
barrier here.

However, to make users enjoy Endless OS as much as possible, this patch
clears the require_force_probe flag for Jasper Lake's DRM.

This approach should be removed if Intel enables Jasper Lake chips well.

This will be different after kernel 5.11+ due to the commit 24ea098b7c0d
("drm/i915/jsl: Split EHL/JSL platform info and PCI ids").

https://phabricator.endlessm.com/T31213

Signed-off-by: Jian-Hong Pan <jhp@endlessos.org>