### PR TITLE
UBUNTU: SAUCE: seq_file: Disallow extremely large seq buffer allocations

### DIFF
--- a/fs/seq_file.c
+++ b/fs/seq_file.c
@@ -32,6 +32,9 @@ static void seq_set_overflow(struct seq_file *m)
 
 static void *seq_buf_alloc(unsigned long size)
 {
+	if (unlikely(size > MAX_RW_COUNT))
+		return NULL;
+
 	return kvmalloc(size, GFP_KERNEL_ACCOUNT);
 }
 


### PR DESCRIPTION
There is no reasonable need for a buffer larger than this,
and it avoids int overflow pitfalls.

Suggested-by: Al Viro <viro@zeniv.linux.org.uk>
Signed-off-by: Eric Sandeen <sandeen@redhat.com>

CVE-2021-33909
Signed-off-by: Thadeu Lima de Souza Cascardo <cascardo@canonical.com>