### PR TITLE
UBUNTU: SAUCE: seq_file: Disallow extremely large seq buffer allocations

### DIFF
--- a/fs/seq_file.c
+++ b/fs/seq_file.c
@@ -29,6 +29,9 @@ static void seq_set_overflow(struct seq_file *m)
 
 static void *seq_buf_alloc(unsigned long size)
 {
+	if (unlikely(size > MAX_RW_COUNT))
+		return NULL;
+
 	return kvmalloc(size, GFP_KERNEL_ACCOUNT);
 }
 


### PR DESCRIPTION
There is no reasonable need for a buffer larger than this,
and it avoids int overflow pitfalls.

Suggested-by: Al Viro <viro@zeniv.linux.org.uk>
Signed-off-by: Eric Sandeen <sandeen@redhat.com>

CVE-2021-33909
Fixes: 058504edd026 ("fs/seq_file: fallback to vmalloc allocation")
Signed-off-by: Thadeu Lima de Souza Cascardo <cascardo@canonical.com>
Acked-by: Juerg Haefliger <juergh@canonical.com>
Acked-by: Benjamin M Romer <benjamin.romer@canonical.com>