### PR TITLE
Revert "[DROP-ME] packaging: Downgrade dwarves dependent version to >= 1.20"

### DIFF
--- a/debian.master/control.stub.in
+++ b/debian.master/control.stub.in
@@ -36,7 +36,7 @@ Build-Depends:
  dkms <!stage1>,
  curl <!stage1>,
  zstd [amd64 s390x] <!stage1>,
- pahole [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.20) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
+ pahole [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
 Build-Depends-Indep:
  xmlto <!stage1>,
  docbook-utils <!stage1>,


### PR DESCRIPTION
This reverts commit 974101219a701b2f0c56a5ebafc2088178d84e57.

Since libbpf 0.5.0-1~bpo11+1 and dwarves 1.22-4~bpo11+1 have built in
eos:master:core, they can provide the dependent packages for normal
linux 5.15 package now. So, drop the workaround.

https://phabricator.endlessm.com/T33162#929649