### PR TITLE
i915: quirk Weibu F3C DP-to-VGA setup

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_bios.c
+++ b/drivers/gpu/drm/i915/display/intel_bios.c
@@ -2468,6 +2468,12 @@ bool intel_bios_is_port_edp(struct drm_i915_private *dev_priv, enum port port)
 		[PORT_F] = DVO_PORT_DPF,
 	};
 
+	/* Quirky VBT defines eDP internal panel instead of DP. We set it to
+	 * DP so that Linux queries the EDID and sets supported display modes
+	 * based on that, ignoring the bogus panel definition. */
+	if (dev_priv->quirk_weibu_f3c)
+		return false;
+
 	if (HAS_DDI(dev_priv))
 		return dev_priv->vbt.ddi_port_info[port].supports_edp;
 

--- a/drivers/gpu/drm/i915/display/intel_dp.c
+++ b/drivers/gpu/drm/i915/display/intel_dp.c
@@ -6732,6 +6732,11 @@ intel_dp_detect(struct drm_connector *connector,
 	intel_dp_check_service_irq(intel_dp);
 
 out:
+	/* Quirk to set status as disconnected if we didn't get an EDID */
+	if (dev_priv->quirk_weibu_f3c &&
+	    to_intel_connector(connector)->detect_edid == NULL)
+		status = connector_status_disconnected;
+
 	if (status != connector_status_connected && !intel_dp->is_mst)
 		intel_dp_unset_edid(intel_dp);
 
@@ -8144,6 +8149,12 @@ intel_dp_init_connector(struct intel_digital_port *dig_port,
 		    "Adding %s connector on [ENCODER:%d:%s]\n",
 		    type == DRM_MODE_CONNECTOR_eDP ? "eDP" : "DP",
 		    intel_encoder->base.base.id, intel_encoder->base.name);
+
+	/* Poll the EDID to update connection state, since we don't know
+	 * how to access the hotplug state */
+	if (dev_priv->quirk_weibu_f3c)
+		intel_connector->polled = DRM_CONNECTOR_POLL_CONNECT |
+					  DRM_CONNECTOR_POLL_DISCONNECT;
 
 	drm_connector_init(dev, connector, &intel_dp_connector_funcs, type);
 	drm_connector_helper_add(connector, &intel_dp_connector_helper_funcs);

--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -27,6 +27,7 @@
  *
  */
 
+#include <linux/dmi.h>
 #include <linux/acpi.h>
 #include <linux/device.h>
 #include <linux/oom.h>
@@ -803,6 +804,24 @@ i915_driver_create(struct pci_dev *pdev, const struct pci_device_id *ent)
 	return i915;
 }
 
+static const struct dmi_system_id weibu_f3c[] = {
+	{
+		.ident = "Weibu F3C",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Weibu"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "F3C"),
+		},
+	},
+	{
+		.ident = "Endless EE-200",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Endless"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "EE-200"),
+		},
+	},
+	{ }
+};
+
 /**
  * i915_driver_probe - setup chip and create an initial config
  * @pdev: PCI device
@@ -843,6 +862,8 @@ int i915_driver_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 		}
 	}
 #endif
+
+	i915->quirk_weibu_f3c = !!dmi_check_system(weibu_f3c);
 
 	ret = pci_enable_device(pdev);
 	if (ret)

--- a/drivers/gpu/drm/i915/i915_drv.h
+++ b/drivers/gpu/drm/i915/i915_drv.h
@@ -1221,6 +1221,17 @@ struct drm_i915_private {
 	 * NOTE: This is the dri1/ums dungeon, don't add stuff here. Your patch
 	 * will be rejected. Instead look for a better place.
 	 */
+
+	/* The Weibu F3C has a DP-to-VGA converter chip to enable the VGA port.
+	 * However the VBT lists it an internal eDP panel, and we don't know
+	 * how to access the VGA hotplug pin on the converter chip, so we
+	 * resort to polling the EDID and updating connector status based on
+	 * that.
+	 *
+	 * This flag should probably be kept inside intel_dp but we put it
+	 * here in the interests of making this patch as least invasive as
+	 * possible. */
+	bool quirk_weibu_f3c;
 };
 
 static inline struct drm_i915_private *to_i915(const struct drm_device *dev)


### PR DESCRIPTION
The Weibu F3C has a VGA port, enabled through an onboard PS8613
DP-to-VGA converter chip.

However the BIOS describes the DP interface from the SoC as being
hooked up to an internal 1366x768 LCD panel over eDP, with a backlight.

Until we get a fixed BIOS, force it to be detected as DP. That way
we ignore the panel definition, don't register a backlight device,
and we request the EDID over the AUX pins in order to get display modes.

We also have a problem with presence detection and hotplug. The SoC
detects the DP connection as always connected (since the chip is always
there). The PS8613 does have a DP_HPD pin that looks like it could tell
us when the VGA monitor is present and hotplugged, but we don't know how
that is hooked up to the SoC.

In order to work around this limitation, we poll the status every 10
seconds. We force a re-read of the EDID even when there is no connector
state change, and we update the connector status to disconnected if we
fail to read the EDID.

https://phabricator.endlessm.com/T14620