### PR TITLE
[Endless] LSM: Increase LSM blob entries for endlesspayg

### DIFF
--- a/include/linux/security.h
+++ b/include/linux/security.h
@@ -172,6 +172,7 @@ static inline void lsmcontext_init(struct lsmcontext *cp, char *context,
  * Any LSM that provides secid or secctx based hooks must be included.
  */
 #define LSMBLOB_ENTRIES ( \
+	(IS_ENABLED(CONFIG_SECURITY) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_SELINUX) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_SMACK) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_APPARMOR) ? 1 : 0) + \


### PR DESCRIPTION
The commit "UBUNTU: SAUCE: LSM: Create and manage the lsmblob data
structure." introduces the LSMBLOB_ENTRIES to maintain the slots of LSM
blob entries and makes sure it will not be out of boundary. Therefore,
the LSMBLOB_ENTRIES should be increased one more slot for endlesspayg.

However, EOS kernel builds endlesspayg into kernel image directly if
CONFIG_SECURITY is set. So, increase the slot of LSM by checking
CONFIG_SECURITY.

Fixes: "UBUNTU: SAUCE: LSM: Create and manage the lsmblob data structure."

https://phabricator.endlessm.com/T33261