### PR TITLE
[Endless] rtw88: Disable lps_deep_mode and ASPM for RTL8821CE

### DIFF
--- a/drivers/net/wireless/realtek/rtw88/main.c
+++ b/drivers/net/wireless/realtek/rtw88/main.c
@@ -2103,6 +2103,11 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
 	hw->wiphy->wowlan = rtwdev->chip->wowlan_stub;
 	hw->wiphy->max_sched_scan_ssids = rtwdev->chip->max_sched_scan_ssids;
 #endif
+
+	/* Disable Deep PS for 8821CE */
+	if (rtwdev->chip->id == RTW_CHIP_TYPE_8821C)
+		rtw_disable_lps_deep_mode = true;
+
 	rtw_set_supported_band(hw, rtwdev->chip);
 	SET_IEEE80211_PERM_ADDR(hw, rtwdev->efuse.addr);
 

--- a/drivers/net/wireless/realtek/rtw88/pci.c
+++ b/drivers/net/wireless/realtek/rtw88/pci.c
@@ -1784,9 +1784,11 @@ int rtw_pci_probe(struct pci_dev *pdev,
 		goto err_destroy_pci;
 	}
 
-	/* Disable PCIe ASPM L1 while doing NAPI poll for 8821CE */
-	if (rtwdev->chip->id == RTW_CHIP_TYPE_8821C && bridge->vendor == PCI_VENDOR_ID_INTEL)
+	/* Disable both common ASPM and PCIe ASPM L1 while doing NAPI poll for 8821CE */
+	if (rtwdev->chip->id == RTW_CHIP_TYPE_8821C && bridge->vendor == PCI_VENDOR_ID_INTEL) {
+		rtw_pci_disable_aspm = true;
 		rtwpci->rx_no_aspm = true;
+	}
 
 	rtw_pci_phy_cfg(rtwdev);
 


### PR DESCRIPTION
Realtek RTL8821CE wireless keeps failed from time to time. All clues
point to power management things between rtw88 and the firmware. We do
not have a better solution currently. So, disable the lps_deep_mode and
ASPM for RTL8821CE as a workaround now.

https://phabricator.endlessm.com/T33794