### PR TITLE
Do not compress the kernel modules with ZSTD

### DIFF
--- a/debian.master/config/annotations
+++ b/debian.master/config/annotations
@@ -378,9 +378,6 @@ CONFIG_MMC_SDHCI_PLTFM                          note<'boot essential on highbank
 CONFIG_MODIFY_LDT_SYSCALL                       policy<{'amd64': 'y'}>
 CONFIG_MODIFY_LDT_SYSCALL                       note<'Q: check this with security'>
 
-CONFIG_MODULE_COMPRESS_ZSTD                     policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 'riscv64': 'y', 's390x': 'y'}>
-CONFIG_MODULE_COMPRESS_ZSTD                     note<'LP: #2028568'>
-
 CONFIG_MODVERSIONS                              policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 'riscv64': 'y', 's390x': 'y'}>
 CONFIG_MODVERSIONS                              note<'required as we have a livepatch/drivers modules signing key'>
 
@@ -7904,10 +7901,10 @@ CONFIG_MODULES_USE_ELF_RELA                     policy<{'amd64': 'y', 'arm64': '
 CONFIG_MODULE_ALLOW_BTF_MISMATCH                policy<{'amd64': 'n', 'arm64': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
 CONFIG_MODULE_ALLOW_MISSING_NAMESPACE_IMPORTS   policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
 CONFIG_MODULE_COMPRESS_GZIP                     policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
-CONFIG_MODULE_COMPRESS_NONE                     policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
+CONFIG_MODULE_COMPRESS_NONE                     policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 'riscv64': 'y', 's390x': 'y'}>
 CONFIG_MODULE_COMPRESS_XZ                       policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
+CONFIG_MODULE_COMPRESS_ZSTD                     policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
 CONFIG_MODULE_DEBUG                             policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
-CONFIG_MODULE_DECOMPRESS                        policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 'riscv64': 'y', 's390x': 'y'}>
 CONFIG_MODULE_FORCE_LOAD                        policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
 CONFIG_MODULE_FORCE_UNLOAD                      policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 'riscv64': 'n', 's390x': 'n'}>
 CONFIG_MODULE_SECTIONS                          policy<{'riscv64': 'y'}>

--- a/debian.master/control.stub.in
+++ b/debian.master/control.stub.in
@@ -37,7 +37,7 @@ Build-Depends:
  libnuma-dev [amd64 arm64 ppc64el s390x] <!stage1>,
  dkms <!stage1>,
  curl <!stage1>,
- zstd <!stage1>,
+ zstd [amd64 s390x] <!stage1>,
  pahole [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
  clang-15 [amd64],
  libclang1-15 [amd64],

--- a/debian/rules.d/2-binary-arch.mk
+++ b/debian/rules.d/2-binary-arch.mk
@@ -567,8 +567,6 @@ define dh_all
 	dh_installchangelogs -p$(1)
 	dh_installdocs -p$(1)
 	dh_compress -p$(1)
-	# Compress kernel modules
-	find debian/$(1) -name '*.ko' -print0 | xargs -0 -n1 -P $(CONCURRENCY_LEVEL) zstd -19 --quiet --rm
 	dh_fixperms -p$(1) -X/boot/
 	dh_shlibdeps -p$(1) $(shlibdeps_opts)
 	dh_installdeb -p$(1)
@@ -627,7 +625,7 @@ binary-%: checks-%
 	dh_testroot
 
 	$(call dh_all,$(pkgimg)) -- -Znone
-	$(call dh_all,$(pkgimg_mods)) -- -Znone
+	$(call dh_all,$(pkgimg_mods))
 
 	dh_installdirs -p$(metapkgimg)
 	dh_installdocs -p$(metapkgimg)
@@ -686,13 +684,13 @@ ifeq ($(do_extras_package),true)
 		| tee -a $(target_flavour).not-shipped.log;
   else
 	if [ -f $(DEBIAN)/control.d/$(target_flavour).inclusion-list ] ; then \
-		$(call dh_all_inline,$(pkgimg_ex)) -- -Znone; \
+		$(call dh_all_inline,$(pkgimg_ex)); \
 	fi
   endif
 endif
 
 	$(foreach _m,$(all_standalone_dkms_modules), \
-	  $(if $(enable_$(_m)),$(call dh_all,$(dkms_$(_m)_pkg_name)-$*) -- -Znone;)\
+	  $(if $(enable_$(_m)),$(call dh_all,$(dkms_$(_m)_pkg_name)-$*);)\
 	)
 
 	$(call dh_all,$(pkgbldinfo))


### PR DESCRIPTION
Do not compress the kernel modules with ZSTD. Busybox cannot handle ZSTD
correctly now. Simply use uncompressed modules.

https://phabricator.endlessm.com/T34954