### PR TITLE
fixup! PCI: Add Intel remapped NVMe device support

### DIFF
--- a/drivers/pci/controller/intel-nvme-remap.c
+++ b/drivers/pci/controller/intel-nvme-remap.c
@@ -384,6 +384,7 @@ static int nvme_remap_probe(struct pci_dev *dev,
 			nr_res->start = res->start;
 			nr_res->end = res->end;
 			nr_res->flags = res->flags;
+			nr_res->parent = res->parent;
 			pci_add_resource(&resources, nr_res);
 		}
 	}
@@ -424,6 +425,16 @@ static int nvme_remap_probe(struct pci_dev *dev,
 
 		/* Share the legacy IRQ between all devices */
 		child->irq = dev->irq;
+
+		if (child->class == PCI_CLASS_STORAGE_SATA_AHCI) {
+			/*
+			 * The new created remapped ACHI controller is a
+			 * virtual interface. The real RAID controller will
+			 * handle the AHCI's PM actions through this module. So,
+			 * skip this virtual interface's PM actions.
+			 */
+			child->skip_bus_pm = 1;
+		}
 	}
 
 	pci_assign_unassigned_bus_resources(nrdev->bus);


### PR DESCRIPTION
The Intel RST RAID enabled machines boot failed, because intel-nvme-remap module creates ROOT bus failed since commit ("PCI: Release resource invalidated by coalescing"). The commit tries to release invalidated resource.

The original intel-nvme-remap did not set the resources' parent memeber of the new remapped PCI bus within the new kernel (5.16+). So, it becomes the invalidated resource which is going to be released.

Besides, make the new generated remapped RAID controller skip the PM actions. Because, it is a virtual interface. The real RAID controller will handle the AHCI's PM actions through the intel-nvme-remap module.

https://phabricator.endlessm.com/T35112