### PR TITLE
ata: ahci: Add force LPM policy quirk for ASUS B1400CEAE

### DIFF
--- a/drivers/acpi/sleep.c
+++ b/drivers/acpi/sleep.c
@@ -385,18 +385,6 @@ static const struct dmi_system_id acpisleep_dmi_table[] __initconst = {
 		DMI_MATCH(DMI_PRODUCT_NAME, "20GGA00L00"),
 		},
 	},
-	/*
-	 * ASUS B1400CEAE hangs on resume from suspend (see
-	 * https://bugzilla.kernel.org/show_bug.cgi?id=215742).
-	 */
-	{
-	.callback = init_default_s3,
-	.ident = "ASUS B1400CEAE",
-	.matches = {
-		DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-		DMI_MATCH(DMI_PRODUCT_NAME, "ASUS EXPERTBOOK B1400CEAE"),
-		},
-	},
 	{},
 };
 


### PR DESCRIPTION
Some systems, like ASUS B1400CEAE equipped with the SATA controller [8086:a0d3] can use LPM policy to save power, especially for s2idle.

However, the same controller may be failed on other platforms. So, commit (ata: ahci: Revert "ata: ahci: Add Tiger Lake UP{3,4} AHCI controller") drops LPM policy for [8086:a0d3]. But, this blocks going to deeper CPU Package C-state when s2idle with enabled Intel VMD.

This patch add ahci_force_lpm_policy DMI quirk for ASUS B1400CEAE to fix s2idle's power consumption issue when Intel VMD feature is enabled.

Link: https://bugzilla.kernel.org/show_bug.cgi?id=218394

https://phabricator.endlessm.com/T35155