### PR TITLE
Fix PAYG LSM lsmid warning

### DIFF
--- a/include/linux/security.h
+++ b/include/linux/security.h
@@ -142,6 +142,7 @@ extern const char *const lockdown_reasons[LOCKDOWN_CONFIDENTIALITY_MAX+1];
 
 #define LSMID_ENTRIES ( \
 	1 + /* capabilities */ \
+	(IS_ENABLED(CONFIG_SECURITY) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_SELINUX) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_SMACK) ? 1 : 0) + \
 	(IS_ENABLED(CONFIG_SECURITY_TOMOYO) ? 1 : 0) + \

--- a/include/uapi/linux/lsm.h
+++ b/include/uapi/linux/lsm.h
@@ -28,6 +28,7 @@
 #define LSM_ID_BPF		42
 #define LSM_ID_LANDLOCK		43
 #define LSM_ID_CAPABILITY	44
+#define LSM_ID_ENDLESSPAYG	45
 
 /*
  * LSM_ATTR_XXX values identify the /proc/.../attr entry that the

--- a/security/endlesspayg/endlesspayg.c
+++ b/security/endlesspayg/endlesspayg.c
@@ -12,6 +12,7 @@
 #include <linux/security.h>
 #include <linux/kernel.h>
 #include <linux/types.h>
+#include <uapi/linux/lsm.h>
 #include "endlesspayg.h"
 
 /* exported in drivers/rtc/dev.c */
@@ -26,6 +27,7 @@ static pid_t paygd_pid = -1;
 
 static struct lsm_id payg_lsmid __ro_after_init = {
 	.lsm  = "endlesspayg",
+	.id   = LSM_ID_ENDLESSPAYG,
 	.slot = LSMBLOB_NEEDED
 };
 


### PR DESCRIPTION
Add Endless PAYG LSM ID to fix the warning oops message when initial PAYG LSM.

https://phabricator.endlessm.com/T35302