### PR TITLE
fixup! wifi: rtw89: 8852be: disable PCI D3Cold by quirk for ECS & Endless SE40AN

### DIFF
--- a/drivers/net/wireless/realtek/rtw89/rtw8852be.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8852be.c
@@ -82,7 +82,7 @@ static const struct dmi_system_id rtw8852b_pci_quirks[] = {
 		.ident = "ECS SE40AN",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ECS"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "SE40AN"),
+			DMI_MATCH(DMI_BOARD_NAME, "SE40AN"),
 		},
 		.driver_data = (void *)RTW89_QUIRK_PCI_NO_D3COLD,
 	},
@@ -90,7 +90,7 @@ static const struct dmi_system_id rtw8852b_pci_quirks[] = {
 		.ident = "Endless SE40AN",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Endless"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "SE40AN"),
+			DMI_MATCH(DMI_BOARD_NAME, "SE40AN"),
 		},
 		.driver_data = (void *)RTW89_QUIRK_PCI_NO_D3COLD,
 	},


### PR DESCRIPTION
Notice ECS' SE40AN series current products' name are variant during this developing time. So, modify the DMI match with the board name, which is consistent.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1213598444155677